### PR TITLE
Migrate page builder sections without properties

### DIFF
--- a/Migration.Toolkit.Core/Mappers/TreeNodeMapper.cs
+++ b/Migration.Toolkit.Core/Mappers/TreeNodeMapper.cs
@@ -233,7 +233,11 @@ public class TreeNodeMapper : EntityMapperBase<CmsTreeMapperSource, TreeNode>
 
             // TODO tk: 2022-09-14 find other acronym for FormComponents
             var sectionFcs = _sourceInstanceContext.GetSectionFormComponents(siteId, section.TypeIdentifier);
-            WalkProperties(section.Properties, sectionFcs);
+
+            if (section.Properties is { Count: > 0 })
+            {
+                WalkProperties(section.Properties, sectionFcs);
+            }
 
             if (section.Zones is { Count: > 0 })
             {

--- a/Migration.Toolkit.Core/Services/CmsClass/EditableAreasConfiguration.cs
+++ b/Migration.Toolkit.Core/Services/CmsClass/EditableAreasConfiguration.cs
@@ -83,7 +83,7 @@ public sealed class SectionConfiguration
     [DataMember]
     [JsonProperty("properties")]
     // public ISectionProperties Properties { get; set; }
-    public JObject Properties { get; set; }
+    public JObject? Properties { get; set; }
 
     /// <summary>Zones within the section.</summary>
     [DataMember]


### PR DESCRIPTION
### Motivation

Migrating page builder sections without properties (properties being null) results in a NullReferenceException. This exception aborts the current migration. 

It should check for the existence of section properties before iterating them. 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

1. Run a migration with a page in the source instance that has a section with no properties. 
2. Verify that the migration of that page is successful.