### PR TITLE
Add warning around Kentico source instances with separated contact management databases

### DIFF
--- a/Migration.Toolkit.CLI/README.md
+++ b/Migration.Toolkit.CLI/README.md
@@ -5,6 +5,10 @@ The [Xperience by Kentico: Kentico Migration Tool](/README.md) transfers content
 
 The migration is performed by running a command for the .NET CLI.
 
+## Set up the source instance
+
+The source instance of Kentico must **not** use a [separated contact management database](https://docs.kentico.com/x/4giRBg), it is recommended that you [rejoin the contact management database](https://docs.kentico.com/x/5giRBg) before proceeding with the migration.
+
 ## Set up the target instance
 
 The target of the migration must be an Xperience by Kentico instance that fulfills the following requirements:


### PR DESCRIPTION
### Motivation

It is not clear that the Migration Tool will error if the contact management database is separated from the main Kentico database.

I think it is worth adding a note to ensure teams re-join the database before proceeding.