### PR TITLE
Add legacy media file allowed content type for migrated field

### DIFF
--- a/KVA/Migration.Tool.Source/Services/AssetFacade.cs
+++ b/KVA/Migration.Tool.Source/Services/AssetFacade.cs
@@ -370,7 +370,7 @@ public class AssetFacade(
         Properties = new FormFieldProperties { FieldCaption = "Asset", },
         Settings = new FormFieldSettings { CustomProperties = new Dictionary<string, object?> { { "AllowedExtensions", "_INHERITED_" } }, ControlName = "Kentico.Administration.ContentItemAssetUploader" }
     };
-    internal static readonly DataClassModel LegacyMediaFileContentType = new()
+    public static readonly DataClassModel LegacyMediaFileContentType = new()
     {
         ClassName = "Legacy.MediaFile",
         ClassType = ClassType.CONTENT_TYPE,

--- a/KVA/Migration.Tool.Source/Services/AssetFacade.cs
+++ b/KVA/Migration.Tool.Source/Services/AssetFacade.cs
@@ -398,7 +398,7 @@ public class AssetFacade(
         Properties = new FormFieldProperties { FieldCaption = "Asset", },
         Settings = new FormFieldSettings { CustomProperties = new Dictionary<string, object?> { { "AllowedExtensions", "_INHERITED_" } }, ControlName = "Kentico.Administration.ContentItemAssetUploader" }
     };
-    internal static readonly DataClassModel LegacyAttachmentContentType = new()
+    public static readonly DataClassModel LegacyAttachmentContentType = new()
     {
         ClassName = "Legacy.Attachment",
         ClassType = ClassType.CONTENT_TYPE,

--- a/Migration.Tool.Extensions/DefaultMigrations/AssetMigration.cs
+++ b/Migration.Tool.Extensions/DefaultMigrations/AssetMigration.cs
@@ -16,6 +16,7 @@ using Migration.Tool.Source.Contexts;
 using Migration.Tool.Source.Helpers;
 using Migration.Tool.Source.Model;
 using Migration.Tool.Source.Services;
+using Newtonsoft.Json;
 
 namespace Migration.Tool.Extensions.DefaultMigrations;
 
@@ -327,11 +328,16 @@ public class AssetMigration(
         columnTypeAttr?.SetValue(configuration.MigrateMediaToMediaLibrary ? FieldDataType.Assets : FieldDataType.ContentItemReference);
 
         var settings = field.EnsureElement(FormDefinitionPatcher.FieldElemSettings);
-        settings.EnsureElement(FormDefinitionPatcher.SettingsElemControlname, e => e.Value = configuration.MigrateMediaToMediaLibrary ? FormComponents.AdminAssetSelectorComponent : FormComponents.AdminContentItemSelectorComponent);
-        settings.EnsureElement(FormDefinitionPatcher.AllowedContentItemTypeIdentifiers, e => e.Value = $"[\"{AssetFacade.LegacyMediaFileContentType.ClassGUID}\"]");
         if (configuration.MigrateMediaToMediaLibrary)
         {
+            settings.EnsureElement(FormDefinitionPatcher.SettingsElemControlname, e => e.Value = FormComponents.AdminAssetSelectorComponent);
             settings.EnsureElement(FormDefinitionPatcher.SettingsMaximumassets, maxAssets => maxAssets.Value = FormDefinitionPatcher.SettingsMaximumassetsFallback);
+        }
+        else
+        {
+            settings.EnsureElement(FormDefinitionPatcher.SettingsElemControlname, e => e.Value = FormComponents.AdminContentItemSelectorComponent);
+            Guid[] allowedContentTypes = [AssetFacade.LegacyMediaFileContentType.ClassGUID!.Value, AssetFacade.LegacyAttachmentContentType.ClassGUID!.Value];
+            settings.EnsureElement(FormDefinitionPatcher.AllowedContentItemTypeIdentifiers, e => e.Value = JsonConvert.SerializeObject(allowedContentTypes.Select(x => x.ToString().ToUpper()).ToArray()));
         }
     }
 }

--- a/Migration.Tool.Extensions/DefaultMigrations/AssetMigration.cs
+++ b/Migration.Tool.Extensions/DefaultMigrations/AssetMigration.cs
@@ -328,6 +328,7 @@ public class AssetMigration(
 
         var settings = field.EnsureElement(FormDefinitionPatcher.FieldElemSettings);
         settings.EnsureElement(FormDefinitionPatcher.SettingsElemControlname, e => e.Value = configuration.MigrateMediaToMediaLibrary ? FormComponents.AdminAssetSelectorComponent : FormComponents.AdminContentItemSelectorComponent);
+        settings.EnsureElement(FormDefinitionPatcher.AllowedContentItemTypeIdentifiers, e => e.Value = $"[\"{AssetFacade.LegacyMediaFileContentType.ClassGUID}\"]");
         if (configuration.MigrateMediaToMediaLibrary)
         {
             settings.EnsureElement(FormDefinitionPatcher.SettingsMaximumassets, maxAssets => maxAssets.Value = FormDefinitionPatcher.SettingsMaximumassetsFallback);

--- a/Migration.Tool.Extensions/DefaultMigrations/AssetMigration.cs
+++ b/Migration.Tool.Extensions/DefaultMigrations/AssetMigration.cs
@@ -337,7 +337,7 @@ public class AssetMigration(
         {
             settings.EnsureElement(FormDefinitionPatcher.SettingsElemControlname, e => e.Value = FormComponents.AdminContentItemSelectorComponent);
             Guid[] allowedContentTypes = [AssetFacade.LegacyMediaFileContentType.ClassGUID!.Value, AssetFacade.LegacyAttachmentContentType.ClassGUID!.Value];
-            settings.EnsureElement(FormDefinitionPatcher.AllowedContentItemTypeIdentifiers, e => e.Value = JsonConvert.SerializeObject(allowedContentTypes.Select(x => x.ToString().ToUpper()).ToArray()));
+            settings.EnsureElement(FormDefinitionPatcher.AllowedContentItemTypeIdentifiers, e => e.Value = JsonConvert.SerializeObject(allowedContentTypes.Select(x => x.ToString()).ToArray()));
         }
     }
 }

--- a/Migration.Tool.KXP.Api/Services/CmsClass/FormDefinitionPatcher.cs
+++ b/Migration.Tool.KXP.Api/Services/CmsClass/FormDefinitionPatcher.cs
@@ -24,6 +24,7 @@ public class FormDefinitionPatcher
     public const string FieldElem = "field";
     public const string FieldElemProperties = "properties";
     public const string FieldElemSettings = "settings";
+    public const string AllowedContentItemTypeIdentifiers = "AllowedContentItemTypeIdentifiers";
     public const string PropertiesElemDefaultvalue = "defaultvalue";
     public const string SettingsElemControlname = "controlname";
     public const string SettingsMaximumassets = "MaximumAssets";


### PR DESCRIPTION
Fix: Add legacy media file allowed content type for migrated field

### Motivation
Fix for reported missing referenced content type in migrated content type field

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Migrate Kentico11 to latest version of Kentico Xperience with migrator tool
Run xperience application.
Open admininstration panel
Go to Confiiguration/Content types page
Open any "Pages" content type
Locate any "Content items" field, open its configuration
**Allowed content type must be filled**
