### PR TITLE
Fix properties migration in case of properties null

### DIFF
--- a/KVA/Migration.Tool.Source/Services/PageBuilderPatcher.cs
+++ b/KVA/Migration.Tool.Source/Services/PageBuilderPatcher.cs
@@ -92,8 +92,12 @@ public class PageBuilderPatcher(
             logger.LogTrace("Walk section {TypeIdentifier}|{Identifier}", section.TypeIdentifier, section.Identifier);
 
             var sectionFcs = sourceInstanceContext.GetSectionFormComponents(siteId, section.TypeIdentifier);
-            bool ndp1 = await MigrateProperties(siteId, section.Properties, sectionFcs, new Dictionary<string, IWidgetPropertyMigration>());
-            needsDeferredPatch = ndp1 || needsDeferredPatch;
+
+            if (section.Properties is { Count: > 0 } properties)
+            {
+                bool ndp1 = await MigrateProperties(siteId, properties, sectionFcs, new Dictionary<string, IWidgetPropertyMigration>());
+                needsDeferredPatch = ndp1 || needsDeferredPatch;
+            }
 
             if (section.Zones is { Count: > 0 })
             {

--- a/Migration.Tool.Common/Model/EditableAreasConfiguration.cs
+++ b/Migration.Tool.Common/Model/EditableAreasConfiguration.cs
@@ -89,7 +89,7 @@ public sealed class SectionConfiguration
     [DataMember]
     [JsonProperty("properties")]
     // public ISectionProperties Properties { get; set; }
-    public JObject Properties { get; set; }
+    public JObject? Properties { get; set; }
 
     /// <summary>Zones within the section.</summary>
     [DataMember]


### PR DESCRIPTION
Fix: Fix properties migration in case of properties null

### Motivation
Fix of reported bug

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

In source instance define a section with properties type = null, create a page with that section and migrate.
