### PR TITLE
Don't ignore excluded class names in custom modules migration

### DIFF
--- a/KVA/Migration.Tool.Source/Handlers/MigrateCustomModulesCommandHandler.cs
+++ b/KVA/Migration.Tool.Source/Handlers/MigrateCustomModulesCommandHandler.cs
@@ -43,7 +43,7 @@ public class MigrateCustomModulesCommandHandler(
 {
     public async Task<CommandResult> Handle(MigrateCustomModulesCommand request, CancellationToken cancellationToken)
     {
-        var entityConfiguration = toolConfiguration.EntityConfigurations.GetEntityConfiguration<ICmsClass>();
+        var entityConfiguration = toolConfiguration.EntityConfigurations.GetEntityConfiguration<DataClassInfo>();
 
         await MigrateResources(cancellationToken);
 


### PR DESCRIPTION
Fix: Don't ignore excluded class names in custom modules migration

### Motivation
Fixes #368 
