### PR TITLE
Adds link to 'Remodel page types as reusable field schemas' guide

### DIFF
--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -698,7 +698,7 @@ The following example specifies two page types from which reusable schemas are c
 },
 ```
 
-For advanced scenarios, you can use the extensibility feature to implement [customizations](../Migration.Tool.Extensions/README.md#custom-class-mappings) that allow you to specify the mapping of page types to reusable field schemas. For example, this allows you to [extract fields from multiple page types into a reusable field schema](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides)
+For advanced scenarios, you can use the extensibility feature to implement [customizations](../Migration.Tool.Extensions/README.md#custom-class-mappings) that allow you to specify the mapping of page types to reusable field schemas. For example, this allows you to [extract fields from multiple page types into a reusable field schema](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides).
 
 ### :warning: Notes
 

--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -141,7 +141,7 @@ You can create [reusable field schemas](https://docs.kentico.com/x/D4_OD) from p
 inherit, by setting
 the `Settings.CreateReusableFieldSchemaForClasses` configuration option. See [Convert page types to reusable field schemas](#convert-page-types-to-reusable-field-schemas) for detailed information.
 
-Additionally, you can use the extensibility feature to implement [customizations](../Migration.Tool.Extensions/README.md) that allow you to inject reusable field schemas into content types.
+Additionally, you can use the extensibility feature to implement [customizations](../Migration.Tool.Extensions/README.md) that allow you to inject reusable field schemas into content types or [extract fields from multiple page types into a shared schema](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides).
 
 #### Content items
 
@@ -698,11 +698,13 @@ The following example specifies two page types from which reusable schemas are c
 },
 ```
 
+For advanced scenarios, you can use the extensibility feature to implement [customizations](../Migration.Tool.Extensions/README.md#custom-class-mappings) that allow you to specify the mapping of page types to reusable field schemas. For example, this allows you to [extract fields from multiple page types into a reusable field schema](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides)
+
 ### :warning: Notes
 
 - Conversion of page types to reusable field schemas works best when all field names of page types are unique (i.e., prefixed with the page type name). If multiple page types converted to reusable field schemas have fields with the same code name, the code name is prefixed with the content type name in the converted reusable field schemas.
 
-- Page types specified by this configuration option are also migrated as content types into to the target instance.
+- Page types specified by the `CreateReusableFieldSchemaForClasses` configuration option are also migrated as content types into to the target instance.
 
 ## Convert text fields with media links
 

--- a/Migration.Tool.Extensions/README.md
+++ b/Migration.Tool.Extensions/README.md
@@ -146,7 +146,7 @@ Register the migration in `Migration.Tool.Extensions/ServiceCollectionExtension
 
 ## Custom class mappings
 
-You can customize class mappings to adjust the content model between the source instance and the target Xperience by Kentico instance. For example, you can merge multiple page types into a single content type, or migrate specific page types to the [content hub](https://docs.kentico.com/x/barWCQ) as reusable content.
+You can customize class mappings to adjust the content model between the source instance and the target Xperience by Kentico instance. For example, you can merge multiple page types into a single content type, remodel page types as [reusable field scehams](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides), or migrate them to the [content hub](https://docs.kentico.com/x/barWCQ) as reusable content.
 
 1. Create a new class.
 2. Add an `IServiceCollection` extension method. Use a separate method for every class mapping that you wish to configure.
@@ -231,7 +231,11 @@ You can customize class mappings to adjust the content model between the source 
 
 **Note**: Your mappings now replace the default migration functionality for all data classes (page types, custom tables or custom module classes) that you use as a source. Any class where you set at least one source field is affected. If you map only some fields from a source class, the remaining fields are not migrated at all.
 
-### Examples
+### Remodel page types as reusable field schemas guide
+
+For an end-to-end example of how to extract common fields from two page types from Kentico Xperience 13 and move them to a [reusable field schema](https://docs.kentico.com/x/D4_OD) shared by both web page content types in Xperience by Kentico follow this [migration guide](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides) in the documentation.
+
+### Sample class mappings
 
 You can find sample class mappings in the [ClassMappingSample.cs](/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs) file.
 


### PR DESCRIPTION
### Motivation

The linked guide showcases a real-world user scenario of migrating page types into reusable field schemas. The links help with the discoverability of the material.

### Checklist

- [x] Docs have been updated (if applicable)
