### PR TITLE
Fix case with publish & unpublish dates both in past

### DIFF
--- a/KVA/Migration.Tool.Source/Mappers/ContentItemMapper.cs
+++ b/KVA/Migration.Tool.Source/Mappers/ContentItemMapper.cs
@@ -245,20 +245,28 @@ public class ContentItemMapper(
             bool ndp = false;
             if (!migratedAsContentFolder)
             {
-                if (cmsDocument.DocumentPublishFrom is { } publishFrom)
+                if (cmsDocument is { DocumentPublishFrom: { } publishFrom1, DocumentPublishTo: null })
                 {
                     if (versionStatus == VersionStatus.Published)
                     {
                         versionStatus = VersionStatus.InitialDraft;
                     }
-                    scheduledPublishWhen = publishFrom;
+                    scheduledPublishWhen = publishFrom1;
                 }
-
-                if (cmsDocument.DocumentPublishTo is { } publishTo)
+                else if (cmsDocument is { DocumentPublishFrom: null, DocumentPublishTo: { } publishTo1 })
                 {
                     if (versionStatus == VersionStatus.Published)
                     {
-                        scheduleUnpublishWhen = publishTo;
+                        scheduleUnpublishWhen = publishTo1;
+                    }
+                }
+                else if (cmsDocument is { DocumentPublishFrom: { } publishFrom2, DocumentPublishTo: { } publishTo2 })
+                {
+                    if (versionStatus == VersionStatus.Published)
+                    {
+                        versionStatus = VersionStatus.InitialDraft;
+                        scheduledPublishWhen = publishFrom2;
+                        scheduleUnpublishWhen = publishTo2;
                     }
                 }
 


### PR DESCRIPTION
### Motivation
Fixes #430 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Set page publish date in source instance to DP, where DP is in the past. Set the same page unpublish date to DU where DU>DP && DU is also in the past. Configure the page's source class to be migrated to content hub. See if item is unpublished and manipulating the item via UI works.