### PR TITLE
Add automatic reusable schema generation for custom class mapping

### DIFF
--- a/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
+++ b/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
@@ -4,8 +4,10 @@ using CMS.FormEngine;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Migration.Tool.Common;
+using Migration.Tool.Common.Abstractions;
 using Migration.Tool.Common.Builders;
 using Migration.Tool.Common.Enumerations;
+using Migration.Tool.KXP.Api;
 using Migration.Tool.KXP.Api.Services.CmsClass;
 using Migration.Tool.Source.Contexts;
 using Migration.Tool.Source.Helpers;
@@ -22,7 +24,9 @@ public class ClassMappingProvider(
     ReusableSchemaService reusableSchemaService,
     IFieldMigrationService fieldMigrationService,
     ToolConfiguration configuration,
-    IEnumerable<IReusableSchemaBuilder> reusableSchemaBuilders)
+    IEnumerable<IReusableSchemaBuilder> reusableSchemaBuilders,
+    KxpClassFacade kxpClassFacade,
+    IEntityMapper<ICmsClass, DataClassInfo> dataClassMapper)
 {
     private readonly List<IClassMapping> configuredClassMappings = [];
     private bool settingsInitialized = false;
@@ -220,53 +224,93 @@ public class ClassMappingProvider(
         foreach (var reusableSchemaBuilder in reusableSchemaBuilders)
         {
             reusableSchemaBuilder.AssertIsValid();
-            var fieldInfos = reusableSchemaBuilder.FieldBuilders.Select(fb =>
+
+            if (reusableSchemaBuilder.SourceClassName is not null)
             {
-                switch (fb)
+                var ksClass = modelFacade.SelectWhere<ICmsClass>("ClassName = @className", new SqlParameter("className", reusableSchemaBuilder.SourceClassName)).FirstOrDefault();
+                if (ksClass is null)
                 {
-                    case { Factory: { } factory }:
+                    logger.LogError("Source class {ClassName} required for reusable field schema {SchemaName} not found",
+                        reusableSchemaBuilder.SourceClassName, reusableSchemaBuilder.SchemaName);
+                    continue;
+                }
+                var kxoDataClass = kxpClassFacade.GetClass(ksClass.ClassGUID);
+
+                var mapped = dataClassMapper.Map(ksClass, kxoDataClass);
+
+                try
+                {
+                    if (mapped is { Success: true })
                     {
-                        return factory();
-                    }
-                    case { SourceFieldIdentifier: { } fieldIdentifier }:
-                    {
-                        var sourceClass = modelFacade.SelectWhere<ICmsClass>("ClassName=@className", new SqlParameter("className", fieldIdentifier.ClassName)).SingleOrDefault()
-                                          ?? throw new InvalidOperationException($"Invalid reusable schema field builder for field '{fieldIdentifier.ClassName}': DataClass not found, class name '{fieldIdentifier.ClassName}'");
-
-                        if (string.IsNullOrWhiteSpace(sourceClass.ClassFormDefinition))
-                        {
-                            throw new InvalidOperationException($"Invalid reusable schema field builder for field '{fieldIdentifier.ClassName}': Class '{fieldIdentifier.ClassName}' is missing field '{fieldIdentifier.FieldName}'");
-                        }
-
-                        // this might be cached as optimization
-                        var patcher = new FormDefinitionPatcher(
-                            logger,
-                            sourceClass.ClassFormDefinition,
-                            fieldMigrationService,
-                            sourceClass.ClassIsForm.GetValueOrDefault(false),
-                            sourceClass.ClassIsDocumentType,
-                            true,
-                            false
-                        );
-
-                        patcher.PatchFields();
-                        patcher.RemoveCategories();
-
-                        var fi = new FormInfo(patcher.GetPatched());
-                        return fi.GetFormField(fieldIdentifier.FieldName) switch
-                        {
-                            { } field => field,
-                            _ => throw new InvalidOperationException($"Invalid reusable schema field builder for field '{fieldIdentifier.ClassName}': Class '{fieldIdentifier.ClassName}' is missing field '{fieldIdentifier.FieldName}'")
-                        };
-                    }
-                    default:
-                    {
-                        throw new InvalidOperationException($"Invalid reusable schema field builder for field '{fb.TargetFieldName}'");
+                        var (dataClassInfo, _) = mapped;
+                        reusableSchemaService.ConvertToReusableSchema(dataClassInfo!, reusableSchemaBuilder.SchemaName,
+                            reusableSchemaBuilder.SchemaDisplayName, reusableSchemaBuilder.SchemaDescription,
+                            reusableSchemaBuilder.FieldNameTransformation);
                     }
                 }
-            });
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error while saving page type {ClassName}", ksClass.ClassName);
+                }
+            }
+            else
+            {
+                var fieldInfos = reusableSchemaBuilder.FieldBuilders.Select(fb =>
+                {
+                    switch (fb)
+                    {
+                        case { Factory: { } factory }:
+                        {
+                            return factory();
+                        }
+                        case { SourceFieldIdentifier: { } fieldIdentifier }:
+                        {
+                            var sourceClass = modelFacade.SelectWhere<ICmsClass>("ClassName=@className",
+                                                      new SqlParameter("className", fieldIdentifier.ClassName))
+                                                  .SingleOrDefault()
+                                              ?? throw new InvalidOperationException(
+                                                  $"Invalid reusable schema field builder for field '{fieldIdentifier.ClassName}': DataClass not found, class name '{fieldIdentifier.ClassName}'");
 
-            reusableSchemaService.EnsureReusableFieldSchema(reusableSchemaBuilder.SchemaName, reusableSchemaBuilder.SchemaDisplayName, reusableSchemaBuilder.SchemaDescription, fieldInfos.ToArray());
+                            if (string.IsNullOrWhiteSpace(sourceClass.ClassFormDefinition))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Invalid reusable schema field builder for field '{fieldIdentifier.ClassName}': Class '{fieldIdentifier.ClassName}' is missing field '{fieldIdentifier.FieldName}'");
+                            }
+
+                            // this might be cached as optimization
+                            var patcher = new FormDefinitionPatcher(
+                                logger,
+                                sourceClass.ClassFormDefinition,
+                                fieldMigrationService,
+                                sourceClass.ClassIsForm.GetValueOrDefault(false),
+                                sourceClass.ClassIsDocumentType,
+                                true,
+                                false
+                            );
+
+                            patcher.PatchFields();
+                            patcher.RemoveCategories();
+
+                            var fi = new FormInfo(patcher.GetPatched());
+                            return fi.GetFormField(fieldIdentifier.FieldName) switch
+                            {
+                                { } field => field,
+                                _ => throw new InvalidOperationException(
+                                    $"Invalid reusable schema field builder for field '{fieldIdentifier.ClassName}': Class '{fieldIdentifier.ClassName}' is missing field '{fieldIdentifier.FieldName}'")
+                            };
+                        }
+                        default:
+                        {
+                            throw new InvalidOperationException(
+                                $"Invalid reusable schema field builder for field '{fb.TargetFieldName}'");
+                        }
+                    }
+                });
+
+                reusableSchemaService.EnsureReusableFieldSchema(reusableSchemaBuilder.SchemaName,
+                    reusableSchemaBuilder.SchemaDisplayName, reusableSchemaBuilder.SchemaDescription,
+                    fieldInfos.ToArray());
+            }
         }
     }
 

--- a/Migration.Tool.Common/Builders/ReusableSchemaBuilder.cs
+++ b/Migration.Tool.Common/Builders/ReusableSchemaBuilder.cs
@@ -9,8 +9,20 @@ public interface IReusableSchemaBuilder
     string SchemaName { get; }
     string SchemaDisplayName { get; }
     string? SchemaDescription { get; }
+    string? SourceClassName { get; }
+    Func<string, string?>? FieldNameTransformation { get; }
+
     IList<IReusableFieldBuilder> FieldBuilders { get; }
     IReusableFieldBuilder BuildField(string targetFieldName);
+
+    /// <summary>
+    /// Automatically creates reusable field schema based on class in source project
+    /// </summary>
+    /// <param name="sourceClassName">ClassName of the source class</param>
+    /// <param name="transformFieldName">If passed, takes in source field name and outputs target field name</param>
+    /// <returns>Instance of the builder</returns>
+    IReusableSchemaBuilder ConvertFrom(string sourceClassName, Func<string, string?>? transformFieldName = null);
+
     void AssertIsValid();
 }
 
@@ -20,6 +32,8 @@ public class ReusableSchemaBuilder(string schemaName, string displayName, string
     public string SchemaDisplayName { get; } = displayName;
     public string? SchemaDescription { get; } = schemaDescription;
     public IList<IReusableFieldBuilder> FieldBuilders { get; set; } = [];
+    public string? SourceClassName { get; private set; }
+    public Func<string, string?>? FieldNameTransformation { get; private set; }
 
     public IReusableFieldBuilder BuildField(string targetFieldName)
     {
@@ -43,6 +57,20 @@ public class ReusableSchemaBuilder(string schemaName, string displayName, string
             reusableFieldBuilder.AssertIsValid();
         }
     }
+
+    /// <summary>
+    /// Automatically creates reusable field schema based on class in source project
+    /// </summary>
+    /// <param name="sourceClassName">ClassName of the source class</param>
+    /// <param name="transformFieldName">If passed, takes in source field name and outputs target field name</param>
+    /// <returns>Instance of the builder</returns>
+    public IReusableSchemaBuilder ConvertFrom(string sourceClassName, Func<string, string?>? transformFieldName = null)
+    {
+        SourceClassName = sourceClassName;
+        FieldNameTransformation = transformFieldName;
+        return this;
+    }
+
 }
 
 public interface IReusableFieldBuilder

--- a/Migration.Tool.Extensions/ServiceCollectionExtensions.cs
+++ b/Migration.Tool.Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
         // services.AddSimpleRemodelingSample();
         // services.AddReusableRemodelingSample();
         // services.AddReusableSchemaIntegrationSample();
+        // services.AddReusableSchemaAutoGenerationSample();
         // services.AddTransient<ContentItemDirectorBase, SamplePageToWidgetDirector>();
         // services.AddTransient<ContentItemDirectorBase, SampleChildLinkDirector>();
         return services;


### PR DESCRIPTION
Add: Add automatic reusable schema generation for custom class mapping

### Motivation
Allows automatic generation of reusable field schema in custom class mapping user code. 
Instead of building RFS field by field manually, user can use `IReusableSchemaBuilder.ConvertFrom(sourceClassName, ...)`
