### PR TITLE
Use fallback user for attachment/mediafile content hub items

### DIFF
--- a/KVA/Migration.Tool.Source/KsCoreDiExtensions.cs
+++ b/KVA/Migration.Tool.Source/KsCoreDiExtensions.cs
@@ -53,6 +53,7 @@ public static class KsCoreDiExtensions
         services.AddSingleton<IAssetFacade, AssetFacade>();
         services.AddSingleton<ContentFolderService>();
         services.AddSingleton<MediaLinkServiceFactory>();
+        services.AddSingleton<UserService>();
         services.AddSingleton<ClassMappingProvider>();
         services.AddTransient<VisualBuilderPatcher>();
 

--- a/Migration.Tool.Common/Services/UserService.cs
+++ b/Migration.Tool.Common/Services/UserService.cs
@@ -1,0 +1,40 @@
+﻿using CMS.ContentEngine;
+using CMS.Helpers;
+using CMS.Membership;
+using CMS.Workspaces;
+using Kentico.Xperience.UMT.Model;
+using Kentico.Xperience.UMT.Services;
+using Microsoft.Extensions.Logging;
+using Migration.Tool.Common.Helpers;
+
+namespace Migration.Tool.Common.Services;
+public class UserService
+{
+    private HashSet<Guid>? existingUsers;
+
+    private Guid? defaultAdminUserGuid;
+    public Guid? DefaultAdminUserGuid
+    {
+        get
+        {
+            if (defaultAdminUserGuid.HasValue)
+            {
+                return defaultAdminUserGuid.Value;
+            }
+
+            var admins = UserInfo.Provider.Get().WhereEquals(nameof(UserInfo.UserAdministrationAccess), true)
+                .Columns(nameof(UserInfo.UserGUID), nameof(UserInfo.UserName));
+            defaultAdminUserGuid = (admins.FirstOrDefault(x => x.UserName == DefaultAdminName) ?? admins.FirstOrDefault())
+                ?.UserGUID;
+            return defaultAdminUserGuid;
+        }
+    }
+
+    private const string DefaultAdminName = "administrator";
+
+    public bool UserExists(Guid userGuid)
+    {
+        existingUsers ??= UserInfo.Provider.Get().Select(x => x.UserGUID).ToHashSet();
+        return existingUsers.Contains(userGuid);
+    }
+}

--- a/Migration.Tool.Common/Services/UserService.cs
+++ b/Migration.Tool.Common/Services/UserService.cs
@@ -1,11 +1,4 @@
-﻿using CMS.ContentEngine;
-using CMS.Helpers;
-using CMS.Membership;
-using CMS.Workspaces;
-using Kentico.Xperience.UMT.Model;
-using Kentico.Xperience.UMT.Services;
-using Microsoft.Extensions.Logging;
-using Migration.Tool.Common.Helpers;
+﻿using CMS.Membership;
 
 namespace Migration.Tool.Common.Services;
 public class UserService


### PR DESCRIPTION
Add: Use fallback user for attachment/mediafile content hub items

If such a media file or attachment is migrated to content hub, that would result in unassigned created by and modified by user fields in content item language metadata, fallback is used.

### Motivation
Solves #438 
