### PR TITLE
Make proper use of MigrateOnlyMediaFileInfo appsettings key

### DIFF
--- a/KVA/Migration.Tool.Source/Services/MediaFileMigrator.cs
+++ b/KVA/Migration.Tool.Source/Services/MediaFileMigrator.cs
@@ -131,7 +131,7 @@ public class MediaFileMigrator(
         foreach (var (ksMediaLibrary, ksSite, targetMediaLibrary) in migratedMediaLibraries)
         {
             string? sourceMediaLibraryPath = AssetFacade.GetMediaLibraryAbsolutePath(toolConfiguration, ksSite, ksMediaLibrary, modelFacade);
-            bool loadMediaFileData = !string.IsNullOrWhiteSpace(sourceMediaLibraryPath);
+            bool loadMediaFileData = !toolConfiguration.MigrateOnlyMediaFileInfo.GetValueOrDefault(false) && !string.IsNullOrWhiteSpace(sourceMediaLibraryPath);
             var ksMediaFiles = modelFacade.SelectWhere<IMediaFile>("FileLibraryID = @FileLibraryId", new SqlParameter("FileLibraryId", ksMediaLibrary.LibraryID));
 
             foreach (var ksMediaFile in ksMediaFiles)


### PR DESCRIPTION
Add: Make proper use of MigrateOnlyMediaFileInfo appsettings key

### Motivation
Solves https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/issues/450

### How to test
Test all combinations of MigrateOnlyMediaFileInfo and MigrateMediaToMediaLibrary. The disk file of CMS media file shouldn't be accessed if MigrateOnlyMediaFileInfo. End to end proof of this - without any specific assumption about where the code passes through and putting a breakpoint there - can be achieved e.g. by having a huge file and checking the time it takes for migration to complete.