### PR TITLE
Fix migration of pages with related items (URLs not migrated)

### DIFF
--- a/KVA/Migration.Tool.Source/Handlers/MigratePagesCommandHandler.cs
+++ b/KVA/Migration.Tool.Source/Handlers/MigratePagesCommandHandler.cs
@@ -406,7 +406,8 @@ public class MigratePagesCommandHandler(
                                     }
                                     case { Success: true, Imported: ContentItemInfo cii }:
                                     {
-                                        contentItemInfo = cii;
+                                        contentItemInfo ??= cii;    // The first item yielded from mapper is the item of the converted page. Subsequent ones are items referred to by the page.
+                                                                    // We want to catch the page's item, thus the ??= operator.
                                         break;
                                     }
                                     case { Success: true, Imported: ContentItemDataInfo cidi }:


### PR DESCRIPTION
Fix: Fix migration of pages with related items (URLs not migrated)

### Motivation
Fixes #469 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Migrate a page, migration of which results in pages with linked content items, the page's URLs from the source instance must be migrated. Beware that MT generates also default URLs, so for good check, make the source page have a recognizable, manifestly nondefault URL
