### PR TITLE
KX-19639 - Update .gitignore with MCP server definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ appsettings.local.json
 .vs/
 *.sln.DotSettings.user
 Migration.Tool.CLI/appsettings.local.json_
+
+# MCP server definitions
+claude_desktop_config.json
+mcp_config.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ appsettings.local.json
 Migration.Tool.CLI/appsettings.local.json_
 
 # MCP server definitions
+mcp.json
 claude_desktop_config.json
 mcp_config.json


### PR DESCRIPTION
### Motivation
With the adoption of new IDEs there are also new config files that should (probably) not be commited to git. Focus was made on those with MCP server definitions, as there might be API keys to prod instances.
- mcp.json (VS Code, Cursor, JetBrains)
- claude_desktop_config.json (Claude)
- mcp_config.json (Windsurf)

To make sure nobody accidently commit those secrets in git, it was recommend adding those files to gitignore. If we see need to commit these files, team can later remove the .gitignore record, but also they must make sure there is no API keys in the file (e.g. use env variables).