### PR TITLE
fix: media folder workspace targeting

### DIFF
--- a/KVA/Migration.Tool.Source/Services/MediaFileMigratorToContentItem.cs
+++ b/KVA/Migration.Tool.Source/Services/MediaFileMigratorToContentItem.cs
@@ -54,10 +54,11 @@ public class MediaFileMigratorToContentItem(
 
             var directive = GetDirective(new(ksSite, ksMediaLibrary, ksMediaFile));
 
-            var umtContentItem = await assetFacade.FromMediaFile(ksMediaFile, ksMediaLibrary, ksSite, [defaultContentLanguage.ContentLanguageName]);
+            var workspaceGuid = workspaceService.EnsureWorkspace(directive.WorkspaceOptions);
+            var umtContentItem = await assetFacade.FromMediaFile(ksMediaFile, ksMediaLibrary, ksSite, [defaultContentLanguage.ContentLanguageName], workspaceGuid);
 
-            umtContentItem.ContentItemWorkspaceGUID = workspaceService.EnsureWorkspace(directive.WorkspaceOptions);
-            umtContentItem.ContentItemContentFolderGUID = contentFolderService.EnsureFolder(directive.ContentFolderOptions, true, umtContentItem.ContentItemWorkspaceGUID);
+            umtContentItem.ContentItemWorkspaceGUID = workspaceGuid;
+            umtContentItem.ContentItemContentFolderGUID = contentFolderService.EnsureFolder(directive.ContentFolderOptions, true, workspaceGuid);
 
             foreach (var item in umtContentItem.LanguageData)
             {


### PR DESCRIPTION
### Motivation

Fixes an error described in issue #474 with creating directories in the target workspace.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
