### PR TITLE
Fix legacy media folders when name is same and path is different

### DIFF
--- a/Migration.Tool.Common/Services/ContentFolderService.cs
+++ b/Migration.Tool.Common/Services/ContentFolderService.cs
@@ -41,7 +41,7 @@ public class ContentFolderService(IImporter importer, ILogger<ContentFolderServi
             else
             {
                 var folderInfo = ContentFolderInfo.Provider.Get()
-                    .And().WhereEquals(nameof(ContentFolderInfo.ContentFolderDisplayName), folderTemplate.DisplayName)
+                    .And().WhereEquals(nameof(ContentFolderInfo.ContentFolderTreePath), folderTemplate.DisplayName)
                     .And().WhereEquals(nameof(ContentFolderInfo.ContentFolderWorkspaceID), workspaceInfo.WorkspaceID)
                     .FirstOrDefault();
 


### PR DESCRIPTION
Fix: Fix legacy media folders when name is same and path is different

### Motivation
#474 
