### PR TITLE
[DO NOT MERGE] POC - Commerce data migration

### DIFF
--- a/Migration.Tool.CLI/appsettings.json
+++ b/Migration.Tool.CLI/appsettings.json
@@ -56,6 +56,14 @@
         "ExcludeCodeNames": []
       }
     },
-    "MemberIncludeUserSystemFields": "FirstName|MiddleName|LastName|FullName|UserPassword|PreferredCultureCode|PreferredUICultureCode|UserPrivilegeLevel|UserIsExternal|UserPasswordFormat|LastLogon|UserStartingAliasPath|UserLastModified|UserLastLogonInfo|UserIsHidden|UserIsDomain|UserHasAllowedCultures|UserMFRequired|UserMFSecret|UserMFTimestep|UserNickName|UserSignature|UserURLReferrer|UserCampaign|UserCustomData|UserRegistrationInfo|UserActivationDate|UserActivatedByUserID|UserTimeZoneID|UserAvatarID|UserGender|UserDateOfBirth|UserSettingsUserGUID|UserSettingsUserID|UserWaitingForApproval|UserDialogsConfiguration|UserDescription|UserAuthenticationGUID|UserSkype|UserIM|UserPhone|UserPosition|UserLogActivities|UserPasswordRequestHash|UserInvalidLogOnAttempts|UserInvalidLogOnAttemptsHash|UserPasswordLastChanged|UserAccountLockReason|UserShowIntroductionTile|UserDashboardApplications|UserDismissedSmartTips"
+    "MemberIncludeUserSystemFields": "FirstName|MiddleName|LastName|FullName|UserPassword|PreferredCultureCode|PreferredUICultureCode|UserPrivilegeLevel|UserIsExternal|UserPasswordFormat|LastLogon|UserStartingAliasPath|UserLastModified|UserLastLogonInfo|UserIsHidden|UserIsDomain|UserHasAllowedCultures|UserMFRequired|UserMFSecret|UserMFTimestep|UserNickName|UserSignature|UserURLReferrer|UserCampaign|UserCustomData|UserRegistrationInfo|UserActivationDate|UserActivatedByUserID|UserTimeZoneID|UserAvatarID|UserGender|UserDateOfBirth|UserSettingsUserGUID|UserSettingsUserID|UserWaitingForApproval|UserDialogsConfiguration|UserDescription|UserAuthenticationGUID|UserSkype|UserIM|UserPhone|UserPosition|UserLogActivities|UserPasswordRequestHash|UserInvalidLogOnAttempts|UserInvalidLogOnAttemptsHash|UserPasswordLastChanged|UserAccountLockReason|UserShowIntroductionTile|UserDashboardApplications|UserDismissedSmartTips",
+    "CommerceConfiguration": {
+      "OrderStatuses": {
+        "XbKStatusCode": [ "KX13StatusCode", "KX13StatusCode2" ]
+      },
+      "OrderFromDate": "",
+      "OrderToDate": "",
+      "CommerceSiteName": "DancingGoatCore"
+    }
   }
 }

--- a/Migration.Tool.Common/Commands.cs
+++ b/Migration.Tool.Common/Commands.cs
@@ -153,3 +153,23 @@ public record MigrateContentTypeRestrictionsCommand : IRequest<CommandResult>, I
 
     public Type[] Dependencies => [typeof(MigrateSitesCommand), typeof(MigratePageTypesCommand), typeof(MigratePagesCommand)];
 }
+
+public record MigrateCustomersCommand : IRequest<CommandResult>, ICommand
+{
+    public static readonly int Rank = 1 + MigrateSitesCommand.Rank + MigrateCustomModulesCommand.Rank + MigrateUsersCommand.Rank + MigrateMembersCommand.Rank; // Adjust based on dependencies
+
+    public static string Moniker => "customers";
+    public static string MonikerFriendly => "Customers and addresses";
+
+    public Type[] Dependencies => [typeof(MigrateSitesCommand), typeof(MigrateCustomModulesCommand), typeof(MigrateUsersCommand), typeof(MigrateMembersCommand)]; // Define dependencies
+}
+
+public record MigrateOrdersCommand : IRequest<CommandResult>, ICommand
+{
+    public static readonly int Rank = 1 + MigrateSitesCommand.Rank + MigrateCustomModulesCommand.Rank + MigrateUsersCommand.Rank + MigrateMembersCommand.Rank + MigrateCustomersCommand.Rank;
+
+    public static string Moniker => "orders";
+    public static string MonikerFriendly => "Orders";
+
+    public Type[] Dependencies => [typeof(MigrateSitesCommand), typeof(MigrateCustomModulesCommand), typeof(MigrateUsersCommand), typeof(MigrateMembersCommand), typeof(MigrateCustomersCommand)];
+}

--- a/Migration.Tool.Common/CommerceConfiguration.cs
+++ b/Migration.Tool.Common/CommerceConfiguration.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Migration.Tool.Common;
+
+public class CommerceConfiguration
+{
+    [JsonPropertyName(ConfigurationNames.OrderStatuses)]
+    public Dictionary<string, string[]> OrderStatuses { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    [JsonPropertyName(ConfigurationNames.OrderFromDate)]
+    public DateTime? OrderFromDate { get; set; }
+
+    [JsonPropertyName(ConfigurationNames.OrderToDate)]
+    public DateTime? OrderToDate { get; set; }
+
+    [JsonPropertyName(ConfigurationNames.CommerceSiteName)]
+    public string? CommerceSiteName { get; set; }
+}
+

--- a/Migration.Tool.Common/ConfigurationNames.cs
+++ b/Migration.Tool.Common/ConfigurationNames.cs
@@ -72,4 +72,14 @@ public class ConfigurationNames
     public const string XbyKApiSettings = "XbyKApiSettings";
 
     #endregion
+
+    #region Commerce Configuration
+
+    public const string CommerceConfiguration = "CommerceConfiguration";
+    public const string OrderStatuses = "OrderStatuses";
+    public const string OrderFromDate = "OrderFromDate";
+    public const string OrderToDate = "OrderToDate";
+    public const string CommerceSiteName = "CommerceSiteName";
+
+    #endregion
 }

--- a/Migration.Tool.Common/Services/CommandParser.cs
+++ b/Migration.Tool.Common/Services/CommandParser.cs
@@ -130,6 +130,18 @@ public class CommandParser : ICommandParser
                 continue;
             }
 
+            if (arg == $"--{MigrateCustomersCommand.Moniker}")
+            {
+                subcommands.Add(new MigrateCustomersCommand());
+                continue;
+            }
+
+            if (arg == $"--{MigrateOrdersCommand.Moniker}")
+            {
+                subcommands.Add(new MigrateOrdersCommand());
+                continue;
+            }
+
             throw new InvalidOperationException($"Unknown command '{arg}'");
         }
 
@@ -153,6 +165,7 @@ public class CommandParser : ICommandParser
         WriteCommandDesc($"starts migration of {Green(MigrateMembersCommand.MonikerFriendly)}", $"migrate --{MigrateMembersCommand.Moniker}");
         WriteCommandDesc($"starts migration of {Green(MigrateAttachmentsCommand.MonikerFriendly)}", $"migrate --{MigrateAttachmentsCommand.Moniker}");
         WriteCommandDesc($"starts migration of {Green(MigrateCustomModulesCommand.MonikerFriendly)}", $"migrate --{MigrateCustomModulesCommand.Moniker}");
+        WriteCommandDesc($"starts migration of {Green(MigrateCustomersCommand.MonikerFriendly)}", $"migrate --{MigrateCustomersCommand.Moniker}");
         Console.WriteLine();
         Console.WriteLine($"Command {Green("patch")}: Applies migration patches to XbyK database. Patches are also applied at each run of {Green("migrate")}. Use this command to run patches without migration. " +
             $"Migration patches fix data problems caused by bugs in previous versions of Migration Tool. This command is idempotent - i.e. tolerant to multiple runs.");

--- a/Migration.Tool.Common/ToolConfiguration.cs
+++ b/Migration.Tool.Common/ToolConfiguration.cs
@@ -25,6 +25,9 @@ public class ToolConfiguration
     [ConfigurationKeyName(ConfigurationNames.EntityConfigurations)]
     public EntityConfigurations EntityConfigurations { get; set; } = [];
 
+    [ConfigurationKeyName(ConfigurationNames.CommerceConfiguration)]
+    public CommerceConfiguration? CommerceConfiguration { get; set; }
+
     [ConfigurationKeyName(ConfigurationNames.MigrateOnlyMediaFileInfo)]
     public bool? MigrateOnlyMediaFileInfo { get; set; } = false;
 

--- a/Migration.Tool.Core.KX13/Constants/CommerceConstants.cs
+++ b/Migration.Tool.Core.KX13/Constants/CommerceConstants.cs
@@ -1,0 +1,24 @@
+namespace Migration.Tool.Core.KX13.Constants;
+
+public class CommerceConstants
+{
+    /// <summary>
+    /// Currency code custom field name.
+    /// </summary>
+    /// <remarks>
+    /// This field is used to store the currency code for the order.
+    /// It is because order in XbK doesn't have currency support, so we need to preserved currency value.
+    /// </remarks>
+    public const string CURRENCY_CODE_FIELD_NAME = "CurrencyCode";
+
+
+    /// <summary>
+    /// Site origin custom field name.
+    /// </summary>
+    /// <remarks>
+    /// This field is used to store the site origin for the order.
+    /// It is because order in XbK doesn't have multi store support, so we need to preserved site origin value,
+    /// to be able to identify order and customer origin.
+    /// </remarks>
+    public const string SITE_ORIGIN_FIELD_NAME = "SiteOriginName";
+}

--- a/Migration.Tool.Core.KX13/DependencyInjectionExtensions.cs
+++ b/Migration.Tool.Core.KX13/DependencyInjectionExtensions.cs
@@ -1,3 +1,4 @@
+using CMS.Commerce;
 using CMS.ContactManagement;
 using CMS.DataEngine;
 using CMS.DataProtection;
@@ -5,6 +6,7 @@ using CMS.FormEngine;
 using CMS.Globalization;
 using CMS.MediaLibrary;
 using CMS.Membership;
+
 using Kentico.Xperience.UMT;
 
 using MediatR;
@@ -63,6 +65,11 @@ public static class DependencyInjectionExtensions
         services.AddTransient<IEntityMapper<KX13M.OmContactStatus, ContactStatusInfo>, OmContactStatusMapper>();
         services.AddTransient<IEntityMapper<KX13M.CmsCountry, CountryInfo>, CountryInfoMapper>();
         services.AddTransient<IEntityMapper<KX13M.CmsState, StateInfo>, StateInfoMapper>();
+        services.AddTransient<IEntityMapper<CustomerInfoMapperSource, CustomerInfo>, CustomerInfoMapper>();
+        services.AddTransient<IEntityMapper<CustomerAddressInfoMapperSource, CustomerAddressInfo>, CustomerAddressInfoMapper>();
+        services.AddTransient<IEntityMapper<OrderInfoMapperSource, OrderInfo>, OrderInfoMapper>();
+        services.AddTransient<IEntityMapper<OrderItemInfoMapperSource, OrderItemInfo>, OrderItemInfoMapper>();
+        services.AddTransient<IEntityMapper<OrderAddressInfoMapperSource, OrderAddressInfo>, OrderAddressInfoMapper>();
 
         services.AddUniversalMigrationToolkit();
 

--- a/Migration.Tool.Core.KX13/Handlers/MigrateCustomersCommandHandler.cs
+++ b/Migration.Tool.Core.KX13/Handlers/MigrateCustomersCommandHandler.cs
@@ -1,0 +1,175 @@
+using CMS.Commerce;
+using CMS.Membership;
+
+using MediatR;
+
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Migration.Tool.Common;
+using Migration.Tool.Common.Abstractions;
+using Migration.Tool.Common.MigrationProtocol;
+using Migration.Tool.Core.KX13.Contexts;
+using Migration.Tool.Core.KX13.Mappers;
+using Migration.Tool.KX13.Context;
+using Migration.Tool.KX13.Models;
+
+namespace Migration.Tool.Core.KX13.Handlers;
+
+public class MigrateCustomersCommandHandler(
+    ILogger<MigrateCustomersCommandHandler> logger,
+    IDbContextFactory<KX13Context> kx13ContextFactory,
+    IEntityMapper<CustomerInfoMapperSource, CustomerInfo> customerInfoMapper,
+    IEntityMapper<CustomerAddressInfoMapperSource, CustomerAddressInfo> customerAddressInfoMapper,
+    IProtocol protocol,
+    PrimaryKeyMappingContext primaryKeyMappingContext,
+    ToolConfiguration toolConfiguration)
+    : IRequestHandler<MigrateCustomersCommand, CommandResult>
+{
+    public async Task<CommandResult> Handle(MigrateCustomersCommand request, CancellationToken cancellationToken)
+    {
+        await using var kx13FormsContext = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+        var kx13CommerceSite = await GetCommerceSite(cancellationToken);
+
+        await using var kx13Context = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+        var kx13Customers = kx13Context.ComCustomers
+            .Where(c => c.CustomerSiteId == kx13CommerceSite.SiteId || !c.CustomerSiteId.HasValue)
+            .Include(c => c.ComAddresses)
+            .Include(c => c.ComOrders)
+            .Include(c => c.CustomerUser);
+
+        foreach (var kx13Customer in kx13Customers)
+        {
+            protocol.FetchedSource(kx13Customer);
+            logger.LogTrace("Migrating customer {CustomerId} with CustomerGuid {CustomerGuid}", kx13Customer.CustomerId, kx13Customer.CustomerGuid);
+
+            // There has to be separate context for every collection
+            await using var kx13UserContext = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+
+            var kx13User = kx13UserContext.CmsUsers.FirstOrDefault(u => u.UserId == kx13Customer.CustomerUserId);
+            var xbkCustomerInfo = CustomerInfo.Provider.Get()
+                .WhereEquals(nameof(CustomerInfo.CustomerGUID), kx13Customer.CustomerGuid).FirstOrDefault();
+
+            MemberInfo? xbkMemberInfo = null;
+            if (kx13User is not null)
+            {
+                xbkMemberInfo = MemberInfoProvider.ProviderObject.Get(kx13User.UserGuid);
+                protocol.FetchedTarget(xbkMemberInfo);
+            }
+
+            var mapped = customerInfoMapper.Map(new CustomerInfoMapperSource(kx13Customer, kx13CommerceSite.SiteName, xbkMemberInfo), xbkCustomerInfo);
+            protocol.MappedTarget(mapped);
+
+            SaveUserUsingKenticoApi(mapped!, kx13User);
+
+            if (mapped is { Success: true, Item: CustomerInfo customerInfo })
+            {
+                foreach (var kx13CustomerAddress in kx13Customer.ComAddresses)
+                {
+                    var xbkCustomerAddress = CustomerAddressInfo.Provider.Get().WhereEquals(nameof(CustomerAddressInfo.CustomerAddressGUID), kx13CustomerAddress.AddressGuid).FirstOrDefault();
+                    var mappedAddresses = customerAddressInfoMapper.Map(new CustomerAddressInfoMapperSource(kx13CustomerAddress, customerInfo), xbkCustomerAddress);
+                    protocol.MappedTarget(mappedAddresses);
+                    SaveCustomerAddressUsingKenticoApi(mappedAddresses!, kx13CustomerAddress);
+                }
+            }
+        }
+
+        return new GenericCommandResult();
+    }
+
+
+    private async Task<CmsSite> GetCommerceSite(CancellationToken cancellationToken)
+    {
+        await using var kx13Context = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+        var commerceSiteName = toolConfiguration.CommerceConfiguration?.CommerceSiteName ?? string.Empty;
+        var commerceSite = kx13Context.CmsSites.FirstOrDefault(s => s.SiteName == commerceSiteName);
+
+        return commerceSite ?? throw new InvalidOperationException($"Commerce site {commerceSiteName} not found.");
+    }
+
+
+    private void SaveUserUsingKenticoApi(IModelMappingResult<CustomerInfo> mapped, CmsUser? kx13User)
+    {
+        if (mapped is { Success: true } result)
+        {
+            (var customerInfo, bool newInstance) = result;
+            ArgumentNullException.ThrowIfNull(customerInfo);
+
+            try
+            {
+                CustomerInfo.Provider.Set(customerInfo);
+
+                protocol.Success(kx13User, customerInfo, mapped);
+                logger.LogEntitySetAction(newInstance, customerInfo);
+            }
+            /*Violation in unique index or Violation in unique constraint */
+            catch (DbUpdateException dbUpdateException) when (dbUpdateException.InnerException is SqlException { Number: 2601 or 2627 } sqlException)
+            {
+                logger.LogEntitySetError(sqlException, newInstance, customerInfo);
+                protocol.Append(HandbookReferences.DbConstraintBroken(sqlException, kx13User)
+                    .WithData(kx13User is not null ? new { kx13User.UserName, kx13User.UserGuid, kx13User.UserId } : new { })
+                    .WithMessage("Failed to migrate user, target database broken.")
+                );
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogEntitySetError(ex, newInstance, customerInfo);
+                protocol.Append(HandbookReferences
+                    .ErrorCreatingTargetInstance<UserInfo>(ex)
+                    .NeedsManualAction()
+                    .WithIdentityPrint(customerInfo)
+                );
+                return;
+            }
+
+            // left for OM_Activity
+            if (kx13User is not null)
+            {
+                primaryKeyMappingContext.SetMapping<CmsUser>(r => r.UserId, kx13User.UserId, customerInfo.CustomerID);
+            }
+        }
+    }
+
+
+    private void SaveCustomerAddressUsingKenticoApi(IModelMappingResult<CustomerAddressInfo> mapped, ComAddress kx13CustomerAddress)
+    {
+        if (mapped is { Success: true } result)
+        {
+            (var customerAddressInfo, bool newInstance) = result;
+            ArgumentNullException.ThrowIfNull(customerAddressInfo);
+
+            try
+            {
+                CustomerAddressInfo.Provider.Set(customerAddressInfo);
+
+                protocol.Success(kx13CustomerAddress, customerAddressInfo, mapped);
+                logger.LogEntitySetAction(newInstance, customerAddressInfo);
+            }
+            /*Violation in unique index or Violation in unique constraint */
+            catch (DbUpdateException dbUpdateException) when (dbUpdateException.InnerException is SqlException { Number: 2601 or 2627 } sqlException)
+            {
+                logger.LogEntitySetError(sqlException, newInstance, customerAddressInfo);
+                protocol.Append(HandbookReferences.DbConstraintBroken(sqlException, kx13CustomerAddress)
+                    .WithData(new { kx13CustomerAddress.AddressId, kx13CustomerAddress.AddressGuid })
+                    .WithMessage("Failed to migrate customer address, target database broken.")
+                );
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogEntitySetError(ex, newInstance, customerAddressInfo);
+                protocol.Append(HandbookReferences
+                    .ErrorCreatingTargetInstance<CustomerAddressInfo>(ex)
+                    .NeedsManualAction()
+                    .WithIdentityPrint(customerAddressInfo)
+                );
+                return;
+            }
+
+            // Map primary key for future reference
+            primaryKeyMappingContext.SetMapping<ComAddress>(r => r.AddressId, kx13CustomerAddress.AddressId, customerAddressInfo.CustomerAddressID);
+        }
+    }
+}

--- a/Migration.Tool.Core.KX13/Handlers/MigrateOrdersCommandHandler.cs
+++ b/Migration.Tool.Core.KX13/Handlers/MigrateOrdersCommandHandler.cs
@@ -1,0 +1,378 @@
+using CMS.Commerce;
+using CMS.DataEngine;
+using CMS.FormEngine;
+
+using MediatR;
+
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Migration.Tool.Common;
+using Migration.Tool.Common.Abstractions;
+using Migration.Tool.Common.MigrationProtocol;
+using Migration.Tool.Core.KX13.Constants;
+using Migration.Tool.Core.KX13.Contexts;
+using Migration.Tool.Core.KX13.Mappers;
+using Migration.Tool.KX13.Context;
+using Migration.Tool.KX13.Models;
+using Migration.Tool.KXP.Api;
+using Migration.Tool.KXP.Api.Services.CmsClass;
+
+namespace Migration.Tool.Core.KX13.Handlers;
+
+public class MigrateOrdersCommandHandler(
+    ILogger<MigrateOrdersCommandHandler> logger,
+    IDbContextFactory<KX13Context> kx13ContextFactory,
+    IEntityMapper<OrderInfoMapperSource, OrderInfo> orderInfoMapper,
+    IEntityMapper<OrderItemInfoMapperSource, OrderItemInfo> orderItemInfoMapper,
+    IEntityMapper<OrderAddressInfoMapperSource, OrderAddressInfo> orderAddressInfoMapper,
+    IProtocol protocol,
+    ToolConfiguration toolConfiguration,
+    PrimaryKeyMappingContext primaryKeyMappingContext,
+    IFieldMigrationService fieldMigrationService,
+    KxpClassFacade kxpClassFacade)
+    : IRequestHandler<MigrateOrdersCommand, CommandResult>
+{
+    public async Task<CommandResult> Handle(MigrateOrdersCommand request, CancellationToken cancellationToken)
+    {
+        // Migrate custom fields from KX13 ecommerce.order class to XbK OrderInfo class
+        await MigrateOrderClass(cancellationToken);
+
+        await using var kx13Context = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+        var commerceSiteName = toolConfiguration.CommerceConfiguration?.CommerceSiteName ?? string.Empty;
+
+        var kx13Orders = kx13Context.ComOrders
+            .Include(o => o.OrderSite)
+            .Where(o => o.OrderSite.SiteName == commerceSiteName)
+            .Include(o => o.OrderCurrency)
+            .Include(o => o.ComOrderAddresses)
+            .Include(o => o.OrderStatus)
+            .Include(o => o.OrderCustomer)
+            .Include(o => o.OrderShippingOption)
+            .Include(o => o.OrderPaymentOption);
+
+        await using var kx13OrderStatusContext = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+        var kx13OrderStatuses = kx13OrderStatusContext.ComOrderStatuses.ToList();
+        var commerceConfiguration = toolConfiguration.CommerceConfiguration;
+        var orderStatusesMapping = (commerceConfiguration?.OrderStatuses) ?? throw new InvalidOperationException("Order statuses mapping is not configured.");
+        var xbkOrderStatuses = OrderStatusInfo.Provider.Get().ToList();
+
+        foreach (var kx13Order in kx13Orders)
+        {
+            protocol.FetchedSource(kx13Order);
+            logger.LogTrace("Migrating order {OrderId} with OrderGuid {OrderGuid}", kx13Order.OrderId, kx13Order.OrderGuid);
+
+            // Get the customer info from target database
+            CustomerInfo? xbkCustomerInfo = null;
+            if (kx13Order.OrderCustomer is not null)
+            {
+                xbkCustomerInfo = CustomerInfo.Provider.Get()
+                    .WhereEquals(nameof(CustomerInfo.CustomerGUID), kx13Order.OrderCustomer.CustomerGuid).FirstOrDefault();
+                protocol.FetchedTarget(xbkCustomerInfo);
+            }
+
+            var xbkOrderStatusName = orderStatusesMapping.FirstOrDefault(os => os.Value is not null && os.Value.Contains(kx13Order.OrderStatus?.StatusName, StringComparer.OrdinalIgnoreCase)).Key;
+            if (string.IsNullOrEmpty(xbkOrderStatusName))
+            {
+                logger.LogError("Order status {OrderStatusName} not mapped in settings, skipping order {OrderId}", kx13Order.OrderStatus?.StatusName, kx13Order.OrderId);
+                continue;
+            }
+
+            var xbkOrderStatus = xbkOrderStatuses.FirstOrDefault(os => os.OrderStatusName.Equals(xbkOrderStatusName, StringComparison.OrdinalIgnoreCase));
+            if (xbkOrderStatus is null)
+            {
+                logger.LogError("Order status {OrderStatusName} not found in Kentico, skipping order {OrderId}", xbkOrderStatusName, kx13Order.OrderId);
+                continue;
+            }
+
+            var xbkOrderInfo = OrderInfo.Provider.Get()
+                .WhereEquals(nameof(OrderInfo.OrderGUID), kx13Order.OrderGuid).FirstOrDefault();
+
+            var mapped = orderInfoMapper.Map(new OrderInfoMapperSource(kx13Order, kx13Order.OrderShippingOption?.ShippingOptionDisplayName, kx13Order.OrderPaymentOption?.PaymentOptionDisplayName, kx13Order.OrderCurrency, xbkOrderStatus, xbkCustomerInfo, kx13Order.OrderSite?.SiteName), xbkOrderInfo);
+            protocol.MappedTarget(mapped);
+
+            SaveOrderUsingKenticoApi(mapped!, kx13Order);
+
+            if (mapped is { Success: true, Item: OrderInfo orderInfo })
+            {
+                await using var kx13OrderItemContext = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+                var kx13OrderItems = kx13OrderItemContext.ComOrderItems
+                .Include(oi => oi.OrderItemSku)
+                .Where(oi => oi.OrderItemOrderId == kx13Order.OrderId);
+
+                foreach (var kx13OrderItem in kx13OrderItems)
+                {
+                    var xbkOrderItemInfo = OrderItemInfo.Provider.Get()
+                        .WhereEquals(nameof(OrderItemInfo.OrderItemGUID), kx13OrderItem.OrderItemGuid).FirstOrDefault();
+
+                    var mappedOrderItem = orderItemInfoMapper.Map(new OrderItemInfoMapperSource(kx13OrderItem, orderInfo), xbkOrderItemInfo);
+                    protocol.MappedTarget(mappedOrderItem);
+
+                    SaveOrderItemUsingKenticoApi(mappedOrderItem!, kx13OrderItem);
+                }
+
+                if (kx13Order.OrderCustomer is not null)
+                {
+                    await using var kx13OrderAddressContext = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+                    var kx13OrderAddresses = kx13OrderAddressContext.ComOrderAddresses
+                        .Where(oa => oa.AddressOrderId == kx13Order.OrderId);
+
+                    foreach (var kx13OrderAddress in kx13OrderAddresses)
+                    {
+                        var xbkOrderAddressInfo = OrderAddressInfo.Provider.Get()
+                            .WhereEquals(nameof(OrderAddressInfo.OrderAddressGUID), kx13OrderAddress.AddressGuid).FirstOrDefault();
+
+                        var mappedOrderAddress = orderAddressInfoMapper.Map(new OrderAddressInfoMapperSource(kx13OrderAddress, kx13Order.OrderCustomer, orderInfo), xbkOrderAddressInfo);
+                        protocol.MappedTarget(mappedOrderAddress);
+
+                        SaveOrderAddressUsingKenticoApi(mappedOrderAddress!, kx13OrderAddress);
+                    }
+                }
+
+            }
+        }
+
+        return new GenericCommandResult();
+    }
+
+
+    private void SaveOrderUsingKenticoApi(IModelMappingResult<OrderInfo> mapped, ComOrder kx13Order)
+    {
+        if (mapped is { Success: true } result)
+        {
+            (var orderInfo, bool newInstance) = result;
+            ArgumentNullException.ThrowIfNull(orderInfo);
+
+            try
+            {
+                OrderInfo.Provider.Set(orderInfo);
+
+                protocol.Success(kx13Order, orderInfo, mapped);
+                logger.LogEntitySetAction(newInstance, orderInfo);
+            }
+            /*Violation in unique index or Violation in unique constraint */
+            catch (DbUpdateException dbUpdateException) when (dbUpdateException.InnerException is SqlException { Number: 2601 or 2627 } sqlException)
+            {
+                logger.LogEntitySetError(sqlException, newInstance, orderInfo);
+                protocol.Append(HandbookReferences.DbConstraintBroken(sqlException, kx13Order)
+                    .WithData(new { kx13Order.OrderId, kx13Order.OrderGuid })
+                    .WithMessage("Failed to migrate order, target database broken.")
+                );
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogEntitySetError(ex, newInstance, orderInfo);
+                protocol.Append(HandbookReferences
+                    .ErrorCreatingTargetInstance<OrderInfo>(ex)
+                    .NeedsManualAction()
+                    .WithIdentityPrint(orderInfo)
+                );
+                return;
+            }
+
+            // Map primary key for future reference
+            primaryKeyMappingContext.SetMapping<ComOrder>(r => r.OrderId, kx13Order.OrderId, orderInfo.OrderID);
+        }
+    }
+
+
+    private void SaveOrderItemUsingKenticoApi(IModelMappingResult<OrderItemInfo> mapped, ComOrderItem kx13OrderItem)
+    {
+        if (mapped is { Success: true } result)
+        {
+            (var orderItemInfo, bool newInstance) = result;
+            ArgumentNullException.ThrowIfNull(orderItemInfo);
+
+            try
+            {
+                OrderItemInfo.Provider.Set(orderItemInfo);
+
+                protocol.Success(kx13OrderItem, orderItemInfo, mapped);
+                logger.LogEntitySetAction(newInstance, orderItemInfo);
+            }
+            /*Violation in unique index or Violation in unique constraint */
+            catch (DbUpdateException dbUpdateException) when (dbUpdateException.InnerException is SqlException { Number: 2601 or 2627 } sqlException)
+            {
+                logger.LogEntitySetError(sqlException, newInstance, orderItemInfo);
+                protocol.Append(HandbookReferences.DbConstraintBroken(sqlException, kx13OrderItem)
+                    .WithData(new { kx13OrderItem.OrderItemId, kx13OrderItem.OrderItemGuid })
+                    .WithMessage("Failed to migrate order item, target database broken.")
+                );
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogEntitySetError(ex, newInstance, orderItemInfo);
+                protocol.Append(HandbookReferences
+                    .ErrorCreatingTargetInstance<OrderItemInfo>(ex)
+                    .NeedsManualAction()
+                    .WithIdentityPrint(orderItemInfo)
+                );
+                return;
+            }
+
+            // Map primary key for future reference
+            primaryKeyMappingContext.SetMapping<ComOrderItem>(r => r.OrderItemId, kx13OrderItem.OrderItemId, orderItemInfo.OrderItemID);
+        }
+    }
+
+
+    private void SaveOrderAddressUsingKenticoApi(IModelMappingResult<OrderAddressInfo> mapped, ComOrderAddress kx13OrderAddress)
+    {
+        if (mapped is { Success: true } result)
+        {
+            (var orderAddressInfo, bool newInstance) = result;
+            ArgumentNullException.ThrowIfNull(orderAddressInfo);
+
+            try
+            {
+                OrderAddressInfo.Provider.Set(orderAddressInfo);
+
+                protocol.Success(kx13OrderAddress, orderAddressInfo, mapped);
+                logger.LogEntitySetAction(newInstance, orderAddressInfo);
+            }
+            /*Violation in unique index or Violation in unique constraint */
+            catch (DbUpdateException dbUpdateException) when (dbUpdateException.InnerException is SqlException { Number: 2601 or 2627 } sqlException)
+            {
+                logger.LogEntitySetError(sqlException, newInstance, orderAddressInfo);
+                protocol.Append(HandbookReferences.DbConstraintBroken(sqlException, kx13OrderAddress)
+                    .WithData(new { kx13OrderAddress.AddressId, kx13OrderAddress.AddressGuid })
+                    .WithMessage("Failed to migrate order address, target database broken.")
+                );
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogEntitySetError(ex, newInstance, orderAddressInfo);
+                protocol.Append(HandbookReferences
+                    .ErrorCreatingTargetInstance<OrderAddressInfo>(ex)
+                    .NeedsManualAction()
+                    .WithIdentityPrint(orderAddressInfo)
+                );
+                return;
+            }
+
+            // Map primary key for future reference
+            primaryKeyMappingContext.SetMapping<ComOrderAddress>(r => r.AddressId, kx13OrderAddress.AddressId, orderAddressInfo.OrderAddressID);
+        }
+    }
+
+
+    private async Task MigrateOrderClass(CancellationToken cancellationToken)
+    {
+        await using var kx13Context = await kx13ContextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Get KX13 ecommerce.order class definition
+        var kx13OrderClass = kx13Context.CmsClasses
+            .FirstOrDefault(c => c.ClassName == "ecommerce.order");
+
+        if (kx13OrderClass == null)
+        {
+            logger.LogWarning("KX13 ecommerce.order class not found, skipping custom field migration");
+            return;
+        }
+
+        // Get XbK OrderInfo class
+        var xbkOrderClass = kxpClassFacade.GetClass(OrderInfo.TYPEINFO.ObjectClassName);
+        if (xbkOrderClass == null)
+        {
+            logger.LogWarning("XbK OrderInfo class not found, skipping custom field migration");
+            return;
+        }
+
+        // Patch KX13 form definition
+        var patcher = new FormDefinitionPatcher(
+            logger,
+            kx13OrderClass.ClassFormDefinition,
+            fieldMigrationService,
+            false, // classIsForm
+            false, // classIsDocumentType
+            true,  // discardSysFields (remove system fields, keep custom)
+            false  // classIsCustom
+        );
+        patcher.PatchFields();
+        patcher.RemoveCategories();
+
+        var patchedDefinition = patcher.GetPatched();
+        if (string.IsNullOrWhiteSpace(patchedDefinition))
+        {
+            logger.LogDebug("No custom fields found in KX13 ecommerce.order class");
+            return;
+        }
+
+        // Merge custom fields into XbK class
+        var xbkFormInfo = new FormInfo(xbkOrderClass.ClassFormDefinition);
+        var kx13FormInfo = new FormInfo(patchedDefinition);
+        var existingColumns = xbkFormInfo.GetColumnNames();
+        int addedFieldsCount = 0;
+
+        foreach (string? columnName in kx13FormInfo.GetColumnNames())
+        {
+            var field = kx13FormInfo.GetFormField(columnName);
+            if (!field.PrimaryKey && !field.System && !existingColumns.Contains(columnName))
+            {
+                field.System = false;
+                xbkFormInfo.AddFormItem(field);
+                addedFieldsCount++;
+                logger.LogInformation("Added custom field '{FieldName}' to OrderInfo class", columnName);
+            }
+        }
+
+        // Add custom CurrencyCode field if it doesn't exist
+        if (!existingColumns.Contains(CommerceConstants.CURRENCY_CODE_FIELD_NAME) && !kx13FormInfo.GetColumnNames().Contains(CommerceConstants.CURRENCY_CODE_FIELD_NAME))
+        {
+            var currencyCodeField = new FormFieldInfo
+            {
+                Name = CommerceConstants.CURRENCY_CODE_FIELD_NAME,
+                DataType = FieldDataType.Text,
+                Size = 10,
+                AllowEmpty = true,
+                System = false,
+                Visible = true,
+                Enabled = true,
+                Caption = "Currency Code",
+                Guid = Guid.NewGuid()
+            };
+            //currencyCodeField.Settings["controlname"] = FormComponents.AdminTextInputComponent;
+
+            xbkFormInfo.AddFormItem(currencyCodeField);
+            addedFieldsCount++;
+            logger.LogInformation("Added new custom field '{FieldName}' to OrderInfo class", CommerceConstants.CURRENCY_CODE_FIELD_NAME);
+        }
+
+        // Add custom SiteOriginName field if it doesn't exist
+        if (!existingColumns.Contains(CommerceConstants.SITE_ORIGIN_FIELD_NAME) && !kx13FormInfo.GetColumnNames().Contains(CommerceConstants.SITE_ORIGIN_FIELD_NAME))
+        {
+            var siteOriginNameField = new FormFieldInfo
+            {
+                Name = CommerceConstants.SITE_ORIGIN_FIELD_NAME,
+                DataType = FieldDataType.Text,
+                Size = 200,
+                AllowEmpty = true,
+                System = false,
+                Visible = true,
+                Enabled = true,
+                Caption = "Site Origin Name",
+                Guid = Guid.NewGuid()
+            };
+
+            xbkFormInfo.AddFormItem(siteOriginNameField);
+            addedFieldsCount++;
+            logger.LogInformation("Added new custom field '{FieldName}' to OrderInfo class", CommerceConstants.SITE_ORIGIN_FIELD_NAME);
+        }
+
+        if (addedFieldsCount > 0)
+        {
+            xbkOrderClass.ClassFormDefinition = xbkFormInfo.GetXmlDefinition();
+            DataClassInfoProvider.ProviderObject.Set(xbkOrderClass);
+            logger.LogInformation("Migrated {Count} custom field(s) to OrderInfo class", addedFieldsCount);
+        }
+        else
+        {
+            logger.LogDebug("No new custom fields to migrate to OrderInfo class");
+        }
+    }
+}
+

--- a/Migration.Tool.Core.KX13/Mappers/CustomerAddressInfoMapper.cs
+++ b/Migration.Tool.Core.KX13/Mappers/CustomerAddressInfoMapper.cs
@@ -1,0 +1,66 @@
+using CMS.Commerce;
+
+using Microsoft.Extensions.Logging;
+using Migration.Tool.Common.Abstractions;
+using Migration.Tool.Common.Helpers;
+using Migration.Tool.Common.MigrationProtocol;
+using Migration.Tool.Core.KX13.Contexts;
+using Migration.Tool.KX13.Models;
+using Migration.Tool.KXP.Api;
+
+namespace Migration.Tool.Core.KX13.Mappers;
+
+public record CustomerAddressInfoMapperSource(ComAddress Address, CustomerInfo Customer);
+
+
+public class CustomerAddressInfoMapper(
+    ILogger<CustomerAddressInfoMapper> logger,
+    PrimaryKeyMappingContext primaryKeyMappingContext,
+    IProtocol protocol,
+    KxpClassFacade kxpClassFacade)
+    : EntityMapperBase<CustomerAddressInfoMapperSource, CustomerAddressInfo>(logger, primaryKeyMappingContext, protocol)
+{
+
+    protected override CustomerAddressInfo? CreateNewInstance(CustomerAddressInfoMapperSource source, MappingHelper mappingHelper, AddFailure addFailure) => new();
+    protected override CustomerAddressInfo MapInternal(CustomerAddressInfoMapperSource source, CustomerAddressInfo target, bool newInstance, MappingHelper mappingHelper, AddFailure addFailure)
+    {
+        var (address, customer) = source;
+
+        if (!newInstance && address.AddressGuid != target.CustomerAddressGUID)
+        {
+            // assertion failed
+            logger.LogTrace("Assertion failed, entity key mismatch");
+            throw new InvalidOperationException("Assertion failed, entity key mismatch.");
+        }
+
+        target.CustomerAddressGUID = address.AddressGuid.GetValueOrDefault();
+        target.CustomerAddressCustomerID = customer.CustomerID;
+
+        // Split personal name into first and last name
+        var nameParts = address.AddressPersonalName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        target.CustomerAddressFirstName = nameParts.Length > 0 ? nameParts[0] : string.Empty;
+        target.CustomerAddressLastName = nameParts.Length > 1 ? nameParts[1] : string.Empty;
+
+        target.CustomerAddressLine1 = address.AddressLine1;
+        target.CustomerAddressLine2 = address.AddressLine2;
+        target.CustomerAddressCity = address.AddressCity;
+        target.CustomerAddressZip = address.AddressZip;
+        target.CustomerAddressPhone = address.AddressPhone;
+        target.CustomerAddressEmail = customer.CustomerEmail;
+
+        var customized = kxpClassFacade.GetCustomizedFieldInfosAll(CustomerAddressInfo.TYPEINFO.ObjectClassName);
+
+        foreach (var customizedFieldInfo in customized)
+        {
+            string fieldName = customizedFieldInfo.FieldName;
+
+            if (ReflectionHelper<ComAddress>.TryGetPropertyValue(address, fieldName, StringComparison.InvariantCultureIgnoreCase, out object? value))
+            {
+                target.SetValue(fieldName, value);
+            }
+        }
+
+        return target;
+    }
+}
+

--- a/Migration.Tool.Core.KX13/Mappers/CustomerInfoMapper.cs
+++ b/Migration.Tool.Core.KX13/Mappers/CustomerInfoMapper.cs
@@ -1,0 +1,73 @@
+using CMS.Commerce;
+using CMS.Membership;
+
+using Microsoft.Extensions.Logging;
+
+using Migration.Tool.Common.Abstractions;
+using Migration.Tool.Common.Helpers;
+using Migration.Tool.Common.MigrationProtocol;
+using Migration.Tool.Core.KX13.Contexts;
+using Migration.Tool.KX13.Models;
+using Migration.Tool.KXP.Api;
+
+namespace Migration.Tool.Core.KX13.Mappers;
+
+public record CustomerInfoMapperSource(ComCustomer Customer, string? CommerceSiteName, MemberInfo? Member);
+
+
+public class CustomerInfoMapper(
+    ILogger<CustomerInfoMapper> logger,
+    PrimaryKeyMappingContext primaryKeyMappingContext,
+    IProtocol protocol,
+    KxpClassFacade kxpClassFacade)
+    : EntityMapperBase<CustomerInfoMapperSource, CustomerInfo>(logger, primaryKeyMappingContext, protocol)
+{
+
+    protected override CustomerInfo? CreateNewInstance(CustomerInfoMapperSource source, MappingHelper mappingHelper, AddFailure addFailure) => new();
+    protected override CustomerInfo MapInternal(CustomerInfoMapperSource source, CustomerInfo target, bool newInstance, MappingHelper mappingHelper, AddFailure addFailure)
+    {
+        var (customer, commerceSiteName, member) = source;
+
+        if (!newInstance && customer.CustomerGuid != target.CustomerGUID)
+        {
+            // assertion failed
+            logger.LogTrace("Assertion failed, entity key mismatch");
+            throw new InvalidOperationException("Assertion failed, entity key mismatch.");
+        }
+
+        target.CustomerGUID = customer.CustomerGuid;
+
+        if (member is not null)
+        {
+            target.CustomerMemberID = member.MemberID;
+        }
+
+        target.CustomerCreatedWhen = customer.CustomerCreated.GetValueOrDefault();
+        target.CustomerFirstName = customer.CustomerFirstName;
+        target.CustomerLastName = customer.CustomerLastName;
+        target.CustomerEmail = customer.CustomerEmail;
+        target.CustomerPhone = customer.CustomerPhone;
+
+        var customized = kxpClassFacade.GetCustomizedFieldInfosAll(CustomerInfo.TYPEINFO.ObjectClassName);
+
+        var channelNameField = customized.FirstOrDefault(x => x.FieldName == "ChannelName");
+        if (channelNameField is not null)
+        {
+            target.SetValue(channelNameField.FieldName, commerceSiteName);
+        }
+
+        foreach (var customizedFieldInfo in customized)
+        {
+            string fieldName = customizedFieldInfo.FieldName;
+
+            if (ReflectionHelper<ComCustomer>.TryGetPropertyValue(customer, fieldName, StringComparison.InvariantCultureIgnoreCase, out object? value))
+            {
+                target.SetValue(fieldName, value);
+            }
+            // log field if failed only one time
+        }
+
+
+        return target;
+    }
+}

--- a/Migration.Tool.Core.KX13/Mappers/OrderAddressInfoMapper.cs
+++ b/Migration.Tool.Core.KX13/Mappers/OrderAddressInfoMapper.cs
@@ -1,0 +1,94 @@
+using CMS.Commerce;
+using Microsoft.Extensions.Logging;
+using Migration.Tool.Common.Abstractions;
+using Migration.Tool.Common.Helpers;
+using Migration.Tool.Common.MigrationProtocol;
+using Migration.Tool.Core.KX13.Contexts;
+using Migration.Tool.KX13.Models;
+using Migration.Tool.KXP.Api;
+
+namespace Migration.Tool.Core.KX13.Mappers;
+
+public record OrderAddressInfoMapperSource(ComOrderAddress Address, ComCustomer Customer, OrderInfo Order);
+
+
+public class OrderAddressInfoMapper(
+    ILogger<OrderAddressInfoMapper> logger,
+    PrimaryKeyMappingContext primaryKeyMappingContext,
+    IProtocol protocol,
+    KxpClassFacade kxpClassFacade)
+    : EntityMapperBase<OrderAddressInfoMapperSource, OrderAddressInfo>(logger, primaryKeyMappingContext, protocol)
+{
+
+    protected override OrderAddressInfo? CreateNewInstance(OrderAddressInfoMapperSource source, MappingHelper mappingHelper, AddFailure addFailure) => new();
+    protected override OrderAddressInfo MapInternal(OrderAddressInfoMapperSource source, OrderAddressInfo target, bool newInstance, MappingHelper mappingHelper, AddFailure addFailure)
+    {
+        var (address, customer, order) = source;
+
+        if (!newInstance && address.AddressGuid != target.OrderAddressGUID)
+        {
+            // assertion failed
+            logger.LogTrace("Assertion failed, entity key mismatch");
+            throw new InvalidOperationException("Assertion failed, entity key mismatch.");
+        }
+
+        target.OrderAddressGUID = address.AddressGuid.GetValueOrDefault();
+        target.OrderAddressOrderID = order.OrderID;
+
+        // Map AddressType (int) to OrderAddressType (enum with Name property)
+        // Typical mapping: 0 = Billing, 1 = Shipping, 2 = Company
+        var addressType = address.AddressType switch
+        {
+            0 => new OrderAddressType("Unknown"),
+            1 => OrderAddressType.Billing,
+            2 => OrderAddressType.Shipping,
+            3 => new OrderAddressType("Company"),
+            _ => new OrderAddressType("Unknown") // Default to Billing if unknown
+        };
+        target.OrderAddressType = addressType;
+
+        // Split personal name into first and last name
+        var nameParts = address.AddressPersonalName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        target.OrderAddressFirstName = nameParts.Length > 0 ? nameParts[0] : string.Empty;
+        target.OrderAddressLastName = nameParts.Length > 1 ? nameParts[1] : string.Empty;
+
+        //target.OrderAddressCompany
+        target.OrderAddressEmail = customer.CustomerEmail;
+
+        target.OrderAddressLine1 = address.AddressLine1;
+        target.OrderAddressLine2 = address.AddressLine2;
+        target.OrderAddressCity = address.AddressCity;
+        target.OrderAddressZip = address.AddressZip;
+        target.OrderAddressPhone = address.AddressPhone;
+
+        // Map country ID
+        if (mappingHelper.TranslateRequiredId<CmsCountry>(k => k.CountryId, address.AddressCountryId, out int countryId))
+        {
+            target.OrderAddressCountryID = countryId;
+        }
+
+        // Map state ID (optional)
+        if (address.AddressStateId.HasValue)
+        {
+            if (mappingHelper.TryTranslateId<CmsState>(s => s.StateId, address.AddressStateId.Value, out int? stateId))
+            {
+                target.OrderAddressStateID = stateId ?? 0;
+            }
+        }
+
+        var customized = kxpClassFacade.GetCustomizedFieldInfosAll(OrderAddressInfo.TYPEINFO.ObjectClassName);
+
+        foreach (var customizedFieldInfo in customized)
+        {
+            string fieldName = customizedFieldInfo.FieldName;
+
+            if (ReflectionHelper<ComOrderAddress>.TryGetPropertyValue(address, fieldName, StringComparison.InvariantCultureIgnoreCase, out object? value))
+            {
+                target.SetValue(fieldName, value);
+            }
+        }
+
+        return target;
+    }
+}
+

--- a/Migration.Tool.Core.KX13/Mappers/OrderInfoMapper.cs
+++ b/Migration.Tool.Core.KX13/Mappers/OrderInfoMapper.cs
@@ -1,0 +1,91 @@
+using CMS.Commerce;
+
+using Microsoft.Extensions.Logging;
+
+using Migration.Tool.Common.Abstractions;
+using Migration.Tool.Common.Helpers;
+using Migration.Tool.Common.MigrationProtocol;
+using Migration.Tool.Core.KX13.Constants;
+using Migration.Tool.Core.KX13.Contexts;
+using Migration.Tool.KX13.Models;
+using Migration.Tool.KXP.Api;
+
+namespace Migration.Tool.Core.KX13.Mappers;
+
+public record OrderInfoMapperSource
+(ComOrder Order,
+string? ShippingDisplayName,
+string? PaymentDisplayName,
+ComCurrency? Currency,
+OrderStatusInfo OrderStatus,
+CustomerInfo? Customer,
+string? SiteName);
+
+
+public class OrderInfoMapper(
+    ILogger<OrderInfoMapper> logger,
+    PrimaryKeyMappingContext primaryKeyMappingContext,
+    IProtocol protocol,
+    KxpClassFacade kxpClassFacade)
+    : EntityMapperBase<OrderInfoMapperSource, OrderInfo>(logger, primaryKeyMappingContext, protocol)
+{
+
+    protected override OrderInfo? CreateNewInstance(OrderInfoMapperSource source, MappingHelper mappingHelper, AddFailure addFailure) => new();
+    protected override OrderInfo MapInternal(OrderInfoMapperSource source, OrderInfo target, bool newInstance, MappingHelper mappingHelper, AddFailure addFailure)
+    {
+        var (order, shippingDisplayName, paymentDisplayName, currency, orderStatus, customer, siteName) = source;
+
+        if (!newInstance && order.OrderGuid != target.OrderGUID)
+        {
+            // assertion failed
+            logger.LogTrace("Assertion failed, entity key mismatch");
+            throw new InvalidOperationException("Assertion failed, entity key mismatch.");
+        }
+
+        target.OrderGUID = order.OrderGuid;
+
+        if (customer is not null)
+        {
+            target.OrderCustomerID = customer.CustomerID;
+        }
+
+        target.OrderNumber = order.OrderInvoiceNumber;
+        target.OrderCreatedWhen = order.OrderDate;
+        target.OrderTotalPrice = order.OrderTotalPrice;
+        target.OrderTotalTax = order.OrderTotalTax;
+        target.OrderTotalShipping = order.OrderTotalShipping.GetValueOrDefault();
+        target.OrderGrandTotal = order.OrderGrandTotal;
+        target.OrderModifiedWhen = order.OrderLastModified;
+        target.OrderShippingMethodDisplayName = shippingDisplayName;
+        target.OrderPaymentMethodDisplayName = paymentDisplayName;
+        target.OrderShippingMethodPrice = 0;
+
+        target.OrderOrderStatusID = orderStatus.OrderStatusID;
+
+
+        var customized = kxpClassFacade.GetCustomizedFieldInfosAll(OrderInfo.TYPEINFO.ObjectClassName);
+
+        if (currency is not null)
+        {
+            target.SetValue(CommerceConstants.CURRENCY_CODE_FIELD_NAME, currency.CurrencyCode);
+        }
+
+        if (!string.IsNullOrEmpty(siteName))
+        {
+            target.SetValue(CommerceConstants.SITE_ORIGIN_FIELD_NAME, siteName);
+        }
+
+        foreach (var customizedFieldInfo in customized)
+        {
+            string fieldName = customizedFieldInfo.FieldName;
+
+            if (ReflectionHelper<ComOrder>.TryGetPropertyValue(order, fieldName, StringComparison.InvariantCultureIgnoreCase, out object? value))
+            {
+                target.SetValue(fieldName, value);
+            }
+        }
+
+        return target;
+    }
+}
+

--- a/Migration.Tool.Core.KX13/Mappers/OrderItemInfoMapper.cs
+++ b/Migration.Tool.Core.KX13/Mappers/OrderItemInfoMapper.cs
@@ -1,0 +1,60 @@
+using CMS.Commerce;
+
+using Microsoft.Extensions.Logging;
+
+using Migration.Tool.Common.Abstractions;
+using Migration.Tool.Common.Helpers;
+using Migration.Tool.Common.MigrationProtocol;
+using Migration.Tool.Core.KX13.Contexts;
+using Migration.Tool.KX13.Models;
+using Migration.Tool.KXP.Api;
+
+namespace Migration.Tool.Core.KX13.Mappers;
+
+public record OrderItemInfoMapperSource(ComOrderItem OrderItem, OrderInfo Order);
+
+
+public class OrderItemInfoMapper(
+    ILogger<OrderItemInfoMapper> logger,
+    PrimaryKeyMappingContext primaryKeyMappingContext,
+    IProtocol protocol,
+    KxpClassFacade kxpClassFacade)
+    : EntityMapperBase<OrderItemInfoMapperSource, OrderItemInfo>(logger, primaryKeyMappingContext, protocol)
+{
+
+    protected override OrderItemInfo? CreateNewInstance(OrderItemInfoMapperSource source, MappingHelper mappingHelper, AddFailure addFailure) => new();
+    protected override OrderItemInfo MapInternal(OrderItemInfoMapperSource source, OrderItemInfo target, bool newInstance, MappingHelper mappingHelper, AddFailure addFailure)
+    {
+        var (orderItem, order) = source;
+
+        if (!newInstance && orderItem.OrderItemGuid != target.OrderItemGUID)
+        {
+            // assertion failed
+            logger.LogTrace("Assertion failed, entity key mismatch");
+            throw new InvalidOperationException("Assertion failed, entity key mismatch.");
+        }
+
+        target.OrderItemGUID = orderItem.OrderItemGuid;
+        target.OrderItemOrderID = order.OrderID;
+        target.OrderItemSKU = orderItem.OrderItemSku.Skunumber;
+        target.OrderItemName = orderItem.OrderItemSkuname;
+        target.OrderItemQuantity = orderItem.OrderItemUnitCount;
+        target.OrderItemUnitPrice = orderItem.OrderItemUnitPrice;
+        target.OrderItemTotalPrice = orderItem.OrderItemTotalPrice;
+
+        var customized = kxpClassFacade.GetCustomizedFieldInfosAll(OrderItemInfo.TYPEINFO.ObjectClassName);
+
+        foreach (var customizedFieldInfo in customized)
+        {
+            string fieldName = customizedFieldInfo.FieldName;
+
+            if (ReflectionHelper<ComOrderItem>.TryGetPropertyValue(orderItem, fieldName, StringComparison.InvariantCultureIgnoreCase, out object? value))
+            {
+                target.SetValue(fieldName, value);
+            }
+        }
+
+        return target;
+    }
+}
+


### PR DESCRIPTION
This pull request introduces major enhancements to the migration tool by adding support for e-commerce data migration, specifically customers, addresses, and orders. It includes new configuration options, command definitions, dependency injection setup, and core handler implementations. The most important changes are grouped below by theme.

**E-commerce Migration Commands and Handlers**

* Added new migration commands: `MigrateCustomersCommand` and `MigrateOrdersCommand`, with their dependencies and friendly names, enabling migration of customers, addresses, and orders.
* Implemented the `MigrateCustomersCommandHandler` class to handle customer and address migration from KX13 to the target system, including mapping, saving, and error handling logic.

**Configuration and Settings**

* Introduced the `CommerceConfiguration` class and related configuration keys (`OrderStatuses`, `OrderFromDate`, `OrderToDate`, `CommerceSiteName`) to support e-commerce migration settings. Updated `ToolConfiguration` and `appsettings.json` to include these new options. [[1]](diffhunk://#diff-cf294223c8dd771978283132f435c2da4c4266094c022d3361b0adf82dcc7b6aR1-R19) [[2]](diffhunk://#diff-89d1cf35ddc309d739c679b3f4c1e1423922615f3ca388cb2fc76f202b9cbbd8R75-R84) [[3]](diffhunk://#diff-8aaace3fb5c01c7b6444c78c05862614f778a80543444a7fb007262c88c64c2cR28-R30) [[4]](diffhunk://#diff-2c3ed727748d279c00d9c08363fff21077dbc9770ca4fd7dd421609148ee4c88L59-R67)

**Dependency Injection and Mapping**

* Registered new entity mappers for customers, addresses, orders, and order items in the dependency injection setup, ensuring proper mapping during migration.

**Command Parsing and CLI Integration**

* Updated the command parser and CLI help descriptions to recognize and describe the new `customers` and `orders` migration commands. [[1]](diffhunk://#diff-47fc44bfe226375c02aac9611f5705415d3faadf705884d7c86f22bda18f4a30R133-R144) [[2]](diffhunk://#diff-47fc44bfe226375c02aac9611f5705415d3faadf705884d7c86f22bda18f4a30R168)

**Constants and Utility**

* Added `CommerceConstants` for currency code and site origin field names, supporting proper data preservation during migration.