### PR TITLE
Add ability to create fields in class mappings without source mapping

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -82,7 +82,7 @@ dotnet_style_predefined_type_for_locals_parameters_members                = true
 dotnet_style_predefined_type_for_member_access                            = true : error
 dotnet_diagnostic.IDE0049.severity                                        = error
 
-dotnet_style_require_accessibility_modifiers                              = always : error
+dotnet_style_require_accessibility_modifiers                              = for_non_interface_members : error
 dotnet_diagnostic.IDE0040.severity                                        = error
 
 dotnet_style_readonly_field                                               = true : error

--- a/Migration.Tool.Common/Builders/ClassMapper.cs
+++ b/Migration.Tool.Common/Builders/ClassMapper.cs
@@ -6,43 +6,77 @@ namespace Migration.Tool.Common.Builders;
 
 public interface IClassMapping
 {
-    string TargetClassName { get; }
+    public string TargetClassName { get; }
 
-    bool IsMatch(string sourceClassName);
-    void PatchTargetDataClass(DataClassInfo target);
-    ICollection<string> SourceClassNames { get; }
-    string PrimaryKey { get; }
-    IList<IFieldMapping> Mappings { get; }
-    IDictionary<string, Action<FormFieldInfo>> TargetFieldPatchers { get; }
-    IFieldMapping? GetMapping(string targetColumnName, string sourceClassName);
+    public bool IsMatch(string sourceClassName);
+    public void PatchTargetDataClass(DataClassInfo target);
+    public ICollection<string> SourceClassNames { get; }
+    public string PrimaryKey { get; }
+    public IList<IFieldMapping> Mappings { get; }
+    public IDictionary<string, Action<FormFieldInfo>> TargetFieldPatchers { get; }
+    public IFieldMapping? GetMapping(string targetColumnName, string sourceClassName);
 
-    string? GetTargetFieldName(string sourceColumnName, string sourceClassName);
-    string GetSourceFieldName(string targetColumnName, string nodeClassClassName);
-    bool IsCategoryMapped(string sourceClassName, int categoryID);
-    void UseResusableSchema(string reusableSchemaName);
-    IList<string> ReusableSchemaNames { get; }
+    public string? GetTargetFieldName(string sourceColumnName, string sourceClassName);
+    public string GetSourceFieldName(string targetColumnName, string nodeClassClassName);
+    public bool IsCategoryMapped(string sourceClassName, int categoryID);
+    public void UseResusableSchema(string reusableSchemaName);
+    public IList<string> ReusableSchemaNames { get; }
 
     /// <summary>
     /// as for now, supported only for custom tables
     /// </summary>
-    Type? MappingHandler { get; }
+    public Type? MappingHandler { get; }
 }
 
 public interface IFieldMapping
 {
-    bool IsTemplate { get; }
-    string SourceFieldName { get; }
-    string SourceClassName { get; }
-    string TargetFieldName { get; }
+    public bool IsTemplate { get; }
+    public string SourceFieldName { get; }
+    public string SourceClassName { get; }
+    public string TargetFieldName { get; }
 }
 
 public record FieldMapping(string TargetFieldName, string SourceClassName, string SourceFieldName, bool IsTemplate) : IFieldMapping;
 
 public record FieldMappingWithConversion(string TargetFieldName, string SourceClassName, string SourceFieldName, bool IsTemplate, Func<object?, IConvertorContext, object?> Converter) : IFieldMapping;
 
-public class MultiClassMapping(string targetClassName, Action<DataClassInfo> classPatcher = null) : IClassMapping
+public class MultiClassMapping(string targetClassName, Action<DataClassInfo> classPatcher) : IClassMapping
 {
-    public void PatchTargetDataClass(DataClassInfo target) => classPatcher?.Invoke(target);
+    private readonly List<NewFieldDefinition> newFields = [];
+
+    public void PatchTargetDataClass(DataClassInfo target)
+    {
+        classPatcher(target);
+
+        if (newFields.Count > 0)
+        {
+            var formInfo = new FormInfo(target.ClassFormDefinition);
+
+            foreach (var newField in newFields)
+            {
+                if (formInfo.GetFormField(newField.FieldName) != null)
+                {
+                    continue;
+                }
+
+                var formField = new FormFieldInfo
+                {
+                    Name = newField.FieldName,
+                    DataType = newField.DataType,
+                    AllowEmpty = newField.AllowEmpty,
+                    Enabled = true,
+                    Visible = true,
+                    Size = newField.Size
+                };
+
+                formField.Settings ??= new System.Collections.Hashtable();
+
+                newField.FieldPatcher?.Invoke(formField);
+                formInfo.AddFormItem(formField);
+            }
+            target.ClassFormDefinition = formInfo.GetXmlDefinition();
+        }
+    }
 
     ICollection<string> IClassMapping.SourceClassNames => SourceClassNames;
     IList<IFieldMapping> IClassMapping.Mappings => Mappings;
@@ -80,6 +114,31 @@ public class MultiClassMapping(string targetClassName, Action<DataClassInfo> cla
             throw new InvalidOperationException($"Field mapping is already defined for field '{targetFieldName}'");
         }
         return new FieldBuilder(this, targetFieldName);
+    }
+
+    /// <summary>
+    /// Adds a completely new field to the target class that doesn't map from any source field.
+    /// Useful for adding fields like taxonomies, content references, or other new fields that don't exist in the source.
+    /// </summary>
+    /// <param name="fieldName">The name of the new field to add</param>
+    /// <param name="dataType">The data type (e.g., "text", "contentitemreference", "integer")</param>
+    /// <returns>FieldBuilder for fluent configuration with WithFieldPatch()</returns>
+    public FieldBuilder AddField(string fieldName, string dataType = "text")
+    {
+        if (newFields.Any(x => x.FieldName.Equals(fieldName, StringComparison.InvariantCultureIgnoreCase)))
+        {
+            throw new InvalidOperationException($"Field '{fieldName}' is already defined as a new field");
+        }
+
+        var newField = new NewFieldDefinition
+        {
+            FieldName = fieldName,
+            DataType = dataType
+        };
+
+        newFields.Add(newField);
+
+        return new FieldBuilder(this, fieldName, newField);
     }
 
     public bool IsMatch(string sourceClassName) => SourceClassNames.Contains(sourceClassName);
@@ -121,12 +180,40 @@ public interface IMappingHandlerContext;
 
 public record CustomTableMappingHandlerContext(Dictionary<string, object?> Values, DataClassInfo TargetClassInfo, string SourceClassName);
 
-public class FieldBuilder(MultiClassMapping multiClassMapping, string targetFieldName)
+/// <summary>
+/// Defines a new field to be added to the target class schema.
+/// Used by AddField() to create fields that are independent of source data mappings.
+/// </summary>
+public class NewFieldDefinition
 {
+    public string FieldName { get; set; } = null!;
+    public string DataType { get; set; } = "text";
+    public bool AllowEmpty { get; set; } = true;
+    public int Size { get; set; } = 0;
+    public Action<FormFieldInfo>? FieldPatcher { get; set; }
+}
+
+public class FieldBuilder
+{
+    private readonly MultiClassMapping multiClassMapping;
+    private readonly string targetFieldName;
+    private readonly NewFieldDefinition? newFieldDefinition;
     private IFieldMapping? currentFieldMapping;
+
+    public FieldBuilder(MultiClassMapping multiClassMapping, string targetFieldName, NewFieldDefinition? newFieldDefinition = null)
+    {
+        this.multiClassMapping = multiClassMapping;
+        this.targetFieldName = targetFieldName;
+        this.newFieldDefinition = newFieldDefinition;
+    }
 
     public FieldBuilder SetFrom(string sourceClassName, string sourceFieldName, bool isTemplate = false)
     {
+        if (newFieldDefinition != null)
+        {
+            throw new InvalidOperationException($"Cannot set source mapping for new field '{targetFieldName}'. New fields are independent and don't map from source fields.");
+        }
+
         currentFieldMapping = new FieldMapping(targetFieldName, sourceClassName, sourceFieldName, isTemplate);
         multiClassMapping.Mappings.Add(currentFieldMapping);
         multiClassMapping.SourceClassNames.Add(sourceClassName);
@@ -135,6 +222,11 @@ public class FieldBuilder(MultiClassMapping multiClassMapping, string targetFiel
 
     public FieldBuilder ConvertFrom(string sourceClassName, string sourceFieldName, bool isTemplate, Func<object?, IConvertorContext, object?> converter)
     {
+        if (newFieldDefinition != null)
+        {
+            throw new InvalidOperationException($"Cannot set source mapping for new field '{targetFieldName}'. New fields are independent and don't map from source fields.");
+        }
+
         currentFieldMapping = new FieldMappingWithConversion(targetFieldName, sourceClassName, sourceFieldName, isTemplate, converter);
         multiClassMapping.Mappings.Add(currentFieldMapping);
         multiClassMapping.SourceClassNames.Add(sourceClassName);
@@ -143,9 +235,20 @@ public class FieldBuilder(MultiClassMapping multiClassMapping, string targetFiel
 
     public FieldBuilder WithFieldPatch(Action<FormFieldInfo> fieldInfoPatcher)
     {
-        if (!multiClassMapping.TargetFieldPatchers.TryAdd(targetFieldName, fieldInfoPatcher))
+        if (newFieldDefinition != null)
         {
-            throw new InvalidOperationException($"Target field mapper can be dined only once for each field, field '{targetFieldName}' has one already defined");
+            if (newFieldDefinition.FieldPatcher != null)
+            {
+                throw new InvalidOperationException($"Field patcher already defined for new field '{targetFieldName}'");
+            }
+            newFieldDefinition.FieldPatcher = fieldInfoPatcher;
+        }
+        else
+        {
+            if (!multiClassMapping.TargetFieldPatchers.TryAdd(targetFieldName, fieldInfoPatcher))
+            {
+                throw new InvalidOperationException($"Target field mapper can be dined only once for each field, field '{targetFieldName}' has one already defined");
+            }
         }
         return this;
     }

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -71,7 +71,8 @@ public static class ClassMappingSample
 
         // Example of adding a new field that doesn't exist in the source class
         m
-            .AddField("CoffeeRating", "integer")
+            .BuildField("CoffeeRating")
+            .WithoutSource("integer")
             .WithFieldPatch(f =>
             {
                 f.Caption = "Coffee Rating";
@@ -82,7 +83,8 @@ public static class ClassMappingSample
 
         // Example of adding a new taxonomy field
         m
-            .AddField("CoffeeCategories", "taxonomy")
+            .BuildField("CoffeeCategories")
+            .WithoutSource("taxonomy")
             .WithFieldPatch(f =>
             {
                 f.Caption = "Coffee Categories";

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -69,6 +69,30 @@ public static class ClassMappingSample
             .SetFrom(sourceClassName, "CoffeeIsDecaf", true)
             .WithFieldPatch(f => f.SetPropertyValue(FormFieldPropertyEnum.FieldCaption, "IsDecaf RM"));
 
+        // Example of adding a new field that doesn't exist in the source class
+        m
+            .AddField("CoffeeRating", "integer")
+            .WithFieldPatch(f =>
+            {
+                f.Caption = "Coffee Rating";
+                f.AllowEmpty = true;
+                f.DataType = FieldDataType.Integer;
+                f.DefaultValue = "0";
+            });
+
+        // Example of adding a new taxonomy field
+        m
+            .AddField("CoffeeCategories", "taxonomy")
+            .WithFieldPatch(f =>
+            {
+                f.Caption = "Coffee Categories";
+                f.AllowEmpty = true;
+                f.DataType = "taxonomy";
+                f.Settings["controlname"] = "Kentico.Administration.TagSelector";
+                // example of setting taxonomy group by its GUID
+                f.Settings["TaxonomyGroup"] = "[\"1C9D79E0-482E-468C-9C2A-6CBB53BE53F7\"]";
+            });
+
         // register class mapping
         serviceCollection.AddSingleton<IClassMapping>(m);
 
@@ -564,7 +588,7 @@ public static class ClassMappingSample
         //      If you're unsure what the target field type should be, let MT migrate page types (--page-types CLI command)
         //      into a disposable clone of your target instance and see the produced field types.
 
-        var m = new MultiClassMapping("DancingGoatCore.PrefabArticle");
+        var m = new MultiClassMapping("DancingGoatCore.PrefabArticle", _ => { });
         const string sourceClassName = "DancingGoatCore.Article";
 
         // Field mapping


### PR DESCRIPTION
### Motivation

Fixes #551

This PR adds the `AddField()` method to `MultiClassMapping`, enabling developers to create new fields on target content types that don't exist in the source instance. This is useful for adding fields like taxonomies, content item references, or other custom fields during migration that need to be populated through custom logic or left empty for manual population post-migration.

Previously, all fields in class mappings had to be mapped from a source field using `BuildField().SetFrom()`. This limitation prevented adding new fields that are NOT part of a reusable field schema in the target instance and have no corresponding source data.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

---
Automated tests are not included, functionality was tested only manually. Sample usage added to `ClassMappingSample.cs` demonstrating how to add integer and taxonomy fields.