### PR TITLE
Docs/update learn portal links

### DIFF
--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -10,7 +10,7 @@ This document describes how to configure and run the Migration CLI, the main exe
 
 The source instance must **not** use a [separated contact management database](https://docs.kentico.com/x/4giRBg), it is recommended that you [rejoin the contact management database](https://docs.kentico.com/x/5giRBg) before proceeding with the migration.
 
-If you are migrating from Kentico Xperience 13, remember to [update your source instance to Refresh 5 or higher](https://docs.kentico.com/guides/architecture/upgrade-from-kx13/upgrade-faq#do-i-have-to-update-my-kx13-site-before-migration).
+If you are migrating from Kentico Xperience 13, remember to [update your source instance to Refresh 5 or higher](https://docs.kentico.com/guides/upgrade-to-xbyk/upgrade-from-kx13/upgrade-faq#do-i-have-to-update-my-kx13-site-before-migration).
 
 ## Set up the target instance
 
@@ -83,7 +83,7 @@ Migration.Tool.CLI.exe migrate --sites --custom-modules --custom-tables --catego
     successfully.
 
 > [!TIP]
-> Refer to our [FAQ page](https://docs.kentico.com/guides/architecture/upgrade-from-kx13/upgrade-faq#can-i-run-the-kentico-migration-tool-against-my-project-multiple-times) for best practices of performing repeated (iterative) data migration.
+> Refer to our [FAQ page](https://docs.kentico.com/guides/upgrade-to-xbyk/upgrade-from-kx13/upgrade-faq#can-i-run-the-kentico-migration-tool-against-my-project-multiple-times) for best practices of performing repeated (iterative) data migration.
 
 ### Migration Details for Specific Object Types
 
@@ -588,7 +588,6 @@ Add the options under the `Settings` section in the configuration file.
         "CMSConnectionString": "Data Source=myserver;Initial Catalog=XperienceByKentico;Integrated Security=True;Persist Security Info=False;Connect Timeout=120;Encrypt=False;Current Language=English;"
       }
     },
-    "MigrationProtocolPath": "C:\\_Development\\xperience-migration-toolkit-master\\Migration.Tool.Protocol.log",
     "MemberIncludeUserSystemFields": "FirstName|MiddleName|LastName|FullName|UserPrivilegeLevel|UserIsExternal|LastLogon|UserLastModified|UserGender|UserDateOfBirth",
     "ConvertClassesToContentHub": "Acme.Article,Acme.Product,Acme.CustomClass",
     "CustomModuleClassDisplayNamePatterns": {

--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -661,6 +661,25 @@ Add the options under the `Settings` section in the configuration file.
 }
 ```
 
+## Logging
+
+The migration tool uses [.NET logging](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging) with console and file output. Configure log levels and file path in the `Logging` section of `appsettings.json`:
+
+```json
+"Logging": {
+  "LogLevel": {
+    "Default": "Information",
+    "Microsoft": "Warning"
+  },
+  "pathFormat": "logs/log.txt"
+}
+```
+
+- **Console** - Real-time progress with timestamps
+- **Files** - Detailed logs at the specified path (default: `logs/log-<date>.txt`)
+
+To use logging in custom migrations, inject `ILogger<T>` into your class constructor.
+
 ## Source instance API discovery
 
 > :warning: **Warning** – source instance API discovery is only available when migrating from Kentico Xperience 13.

--- a/Migration.Tool.CLI/appsettings.json
+++ b/Migration.Tool.CLI/appsettings.json
@@ -16,7 +16,6 @@
     }
   },
   "Settings": {
-    "MigrationProtocolPath": "C:\\Logs\\protocol.txt",
     "KxConnectionString": "[TODO]",
     "KxCmsDirPath": "[TODO]",
     "XbyKDirPath": "[TODO]",

--- a/Migration.Tool.Common/README.md
+++ b/Migration.Tool.Common/README.md
@@ -17,7 +17,6 @@ Provides shared infrastructure used by all other migration projects:
 - `Commands.cs` - All MediatR commands (MigrateSitesCommand, MigratePagesCommand, etc.)
 - `ToolConfiguration.cs` - Configuration model with validation
 - `IPrinter.cs` / `IPrimaryKeyMappingContext.cs` - Core service abstractions
-- `MigrationProtocol/` - Structured migration result reporting
 - `Abstractions/` - Interfaces for custom migrations and mappers
 - `Services/` - Command line interface parsing and execution logic
 

--- a/Migration.Tool.Extensions/README.md
+++ b/Migration.Tool.Extensions/README.md
@@ -145,7 +145,7 @@ The following sections provide detailed instructions for implementing each type 
 
 ### Custom Class Mappings
 
-You can customize class mappings to adjust the content model between the source instance and the target Xperience by Kentico instance. For example, you can merge multiple page types into a single content type, remodel page types as [reusable field scehams](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides), or migrate them to the [content hub](https://docs.kentico.com/x/barWCQ) as reusable content.
+You can customize class mappings to adjust the content model between the source instance and the target Xperience by Kentico instance. For example, you can merge multiple page types into a single content type, remodel page types as [reusable field schemas](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides), or migrate them to the [content hub](https://docs.kentico.com/x/barWCQ) as reusable content.
 
 1. Create a new class.
 2. Add an `IServiceCollection` extension method. Use a separate method for every class mapping that you wish to configure.
@@ -287,7 +287,7 @@ Implement your decision logic based on available node properties (`NodeClassID`,
 
 #### Available Actions
 
-##### `options.Drop()`
+#### `options.Drop()`
 Skips migration of the linked page entirely. Use for temporary content, archived pages, or content that should be handled manually.
 
 #### `options.Materialize()`
@@ -302,13 +302,10 @@ Creates a content item reference field in an ancestor page that points to the or
 
 #### Common Strategies
 
-**Content Type-Based**: Use `NodeClassID` to look up the content type and apply different strategies based on page type.
-
-**Path-Based**: Filter by `NodeAliasPath` to handle different sections of your site (e.g., archive pages, temporary content).
-
-**Site-Specific**: Use `source.SourceSite.SiteName` to apply different rules for different sites in multi-site scenarios.
-
-**Contextual**: Combine node properties with ancestor analysis to make intelligent decisions about reference placement.
+- **Content Type-Based**: Use `NodeClassID` to look up the content type and apply different strategies based on page type.
+- **Path-Based**: Filter by `NodeAliasPath` to handle different sections of your site (e.g., archive pages, temporary content).
+- **Site-Specific**: Use `source.SourceSite.SiteName` to apply different rules for different sites in multi-site scenarios.
+- **Contextual**: Combine node properties with ancestor analysis to make intelligent decisions about reference placement.
 
 #### Important Considerations
 
@@ -336,7 +333,7 @@ After implementing your linked page director, you need to [register the director
 - **Deferred processing**: Some linked pages may be processed in a second pass if their dependencies aren't ready
 
 **Debugging Tips:**
-- Use logging to track which strategy is applied to each linked page
+- Use [logging](../Migration.Tool.CLI/README.md#logging) to track which strategy is applied to each linked page
 - Verify that ancestor pages exist and have the expected structure
 
 ### Migrate Pages to Widgets

--- a/Migration.Tool.Extensions/README.md
+++ b/Migration.Tool.Extensions/README.md
@@ -20,15 +20,15 @@ The project enables you to:
 - [Available Customization Types](#available-customization-types)
 - [When Custom Migrations Execute](#when-custom-migrations-execute)
 - [Implementation Guides](#implementation-guides)
-  - [Customize Field Migrations](#customize-field-migrations)
-  - [Customize Linked Page Handling](#customize-linked-page-handling)
-  - [Customize Widget Migrations](#customize-widget-migrations)
-  - [Customize Widget Property Migrations](#customize-widget-property-migrations)
-  - [Migrate Pages to Widgets](#migrate-pages-to-widgets)
   - [Custom Class Mappings](#custom-class-mappings)
     - [Remodel Page Types as Reusable Field Schemas Guide](#remodel-page-types-as-reusable-field-schemas-guide)
     - [Sample Class Mappings](#sample-class-mappings)
+  - [Customize Linked Page Handling](#customize-linked-page-handling)
+  - [Migrate Pages to Widgets](#migrate-pages-to-widgets)
   - [Custom Child Links](#custom-child-links)
+  - [Customize Field Migrations](#customize-field-migrations)
+  - [Customize Widget Migrations](#customize-widget-migrations)
+  - [Customize Widget Property Migrations](#customize-widget-property-migrations)
 - [Registration](#registration)
 - [Working with Source and Target APIs](#working-with-source-and-target-apis)
 
@@ -65,16 +65,6 @@ Controls migration behavior and relationships of individual content items during
 - Link child pages as content item references (e.g., link child `Book` pages in a `Books` field when migrating `Author` pages to reusable content)
 - Apply conditional logic based on content structure or hierarchy
 
-### Field Migrations (`IFieldMigration`)
-
-Transforms individual field values during data migration.
-
-**Use cases:**
-
-- Handle custom form controls
-- Convert data formats (date formats, URL structures)
-- Transform content (HTML cleanup, path updates)
-
 ### Widget Migrations (`IWidgetMigration`)
 
 Changes widget types or restructures widget data.
@@ -95,6 +85,16 @@ Transforms individual widget property values.
 - Convert property value formats
 - Transform paths or URLs in widget data
 
+### Field Migrations (`IFieldMigration`)
+
+Transforms individual field values during data migration.
+
+**Use cases:**
+
+- Handle custom form controls
+- Convert data formats (date formats, URL structures)
+- Transform content (HTML cleanup, path updates)
+
 ## When Custom Migrations Execute
 
 When registered, customizations execute based on CLI migration parameters. The order depends on parameter dependencies (e.g., `--pages` requires `--page-types` to run first):
@@ -113,6 +113,22 @@ For detailed information about all available CLI parameters, their dependencies,
 | **Widget Migrations** | `--pages` |
 | **Widget Property Migrations** | `--pages` |
 
+> [!NOTE]
+> Class mappings run before page data migration. Field value transformations defined in class mappings (using `ConvertFrom`) are applied during content type structure migration, not during individual page processing.
+
+**Execution during page migration:**
+
+As multiple custom migrations run during the `--pages` migration, custom migrations execute in the following order for each page:
+
+1. Content item directors control overall behavior (e.g., dropping pages, converting to widgets, handling linked pages)
+2. Widget migrations and widget property migrations transform Page Builder content
+3. Field migrations transform page field values
+
+> [!TIP]
+> Widget migrations execute before content items are saved to the database. To query migrated content items from the database during widget migration (e.g., to modify their property value), run the migration tool twice.
+
+After all pages are migrated, the tool performs a final pass to update `TreePath` properties (converting `NodeAliasPath` references). This happens automatically and doesn't require custom migration logic.
+
 ### Criteria for Custom Migration Execution
 
 The Kentico Migration Tool uses a handler-based architecture where handlers automatically call your custom migrations during data transformation. Typically, you do not interact with handlers directly—simply register your migrations and the migration tool will invoke them automatically.
@@ -123,257 +139,9 @@ Custom migrations are called during transformation:
 2. **Ranking** - If multiple migrations match, the one with the lowest `Rank` value is selected and applied
 3. **Execution** - Once selected, the tool invokes your transformation method to migrate the data (e.g., `MigrateValue()`, `MigrateWidget()`, or `Direct()`)
 
-**Execution during page migration:**
-
-As multiple custom migrations run during the `--pages` migration, custom migrations execute in the following order for each page:
-
-1. Content item directors control overall behavior (e.g., dropping pages, converting to widgets, handling linked pages)
-2. Widget migrations and widget property migrations transform Page Builder content
-3. Field migrations transform page field values
-
-After all pages are migrated, the tool performs a final pass to update `TreePath` properties (converting `NodeAliasPath` references). This happens automatically and doesn't require custom migration logic.
-
-**Overall migration order:**
-
-When running a complete migration with multiple parameters, custom migrations execute in this sequence:
-
-1. **Class mappings** (with `--page-types` or `--custom-modules`) - Define content type structure and field definitions, including value conversions via `ConvertFrom`
-2. **Content item directors, widget migrations, and field migrations** (with `--pages`) - Transform individual page data in the order described above
-
-Note that class mappings run before page data migration, so any field value transformations defined in class mappings (e.g., using `ConvertFrom`) are applied during the content type structure migration, not during individual page processing.
-
 ## Implementation Guides
 
 The following sections provide detailed instructions for implementing each type of custom migration.
-
-### Customize Field Migrations
-
-You can customize field migrations to control how fields are mapped for page types, modules, system objects, and forms. In the `Migration.Tool.Extensions/CommunityMigrations` folder, create a new file with a class that implements the `IFieldMigration` interface. Implement the following properties and methods required by the interface:
-
-- `Rank` - An integer property that determines the order in which migrations are applied. Use a value lower than *100000*, as that is the value for system migrations.
-- `ShallMigrate` - A boolean method that specifies whether the migration shall be applied for the current field. Use properties of the `FieldMigrationContext` object passed as an argument to the method to evaluate the condition. For each field, the migration with the lowest rank that returns `true` from the `ShallMigrate` method is used.
-  - `SourceDataType` - A string property that specifies the [data type](https://docs.kentico.com/x/coJwCg) of the source field.
-  - `SourceFormControl` - A string property that specifies the [form control](https://docs.kentico.com/x/lAyRBg) used by the source field.
-  - `FieldName` - A string property that specifies the code name of the field.
-  - `SourceObjectContext` - An interface that can be used to check the context of the source object (e.g. page vs. form).
-- `MigrateFieldDefinition` - Migrate the definition of the field. Use the `XElement` attribute to transform the field.
-- `MigrateValue` - Migrate the value of the field. Use the source value and the `FieldMigrationContext` with the same parameters as described in `ShallMigrate`.
-
-You can see samples:
-
-- [SampleTextMigration.cs](./CommunityMigrations/SampleTextMigration.cs)
-  - A sample migration with further explanations
-- [AssetMigration.cs](./DefaultMigrations/AssetMigration.cs)
-  - An example of a usable migration
-
-After implementing the migration, you need to [register the migration](#registration) in the system.
-
-### Customize Linked Page Handling
-
-When migrating from Kentico versions that support [linked pages](https://docs.kentico.com/13/managing-website-content/working-with-pages/copying-and-moving-pages-creating-linked-pages#creating-linked-pages) (pages that reference content from other pages in the content tree), you need to decide how to handle them since Xperience by Kentico doesn't support linked pages in the same way.
-
-The linked pages director feature provides a flexible solution to customize how linked pages are handled during migration. You can choose to materialize linked content, drop it entirely, or store references in ancestor pages.
-
-#### Understanding Linked Pages
-
-In older Kentico versions, linked pages allowed you to create pages that displayed content from other pages without duplicating the actual content. This was useful for:
-- Sharing content across multiple sections of a website
-- Creating content references without data duplication  
-- Building complex content hierarchies
-
-#### Migration Strategies
-
-The linked pages director offers three main strategies for handling linked pages:
-
-#### 1. Materialize (Default)
-Creates a full copy of the linked content as an independent page.
-- **Use when**: You want to preserve the content structure but can accept content duplication
-- **Result**: Each linked page becomes a separate content item with its own copy of the data
-
-#### 2. Drop
-Completely skips migration of the linked page.
-- **Use when**: The linked content is no longer needed or should be handled manually
-- **Result**: The linked page will not be migrated to the target instance
-
-#### 3. Store as Reference
-Creates a content item reference field in an ancestor page that points to the original linked content.
-- **Use when**: You want to preserve the relationship without duplicating content
-- **Result**: The linked content is referenced through a content item selector field
-
-#### Implementation
-
-In `Migration.Tool.Extensions/CommunityMigrations`, create a new file with a class that inherits from the `ContentItemDirectorBase` class and override the `DirectLinkedNode(source, options)` method.
-
-The `LinkedPageSource` provides access to:
-- `source.SourceSite` - The site where the linked page exists
-- `source.SourceNode` - The node that contains the link  
-- `source.LinkedNode` - The target node being linked to
-
-Implement your decision logic based on available node properties (`NodeClassID`, `NodeAliasPath`, `NodeName`, etc.) and call the appropriate action method.
-
-#### Available Actions
-
-##### `options.Drop()`
-Skips migration of the linked page entirely. Use for temporary content, archived pages, or content that should be handled manually.
-
-#### `options.Materialize()`
-Creates an independent copy of the linked content (default behavior). This preserves the content structure but results in content duplication.
-
-#### `options.StoreReferenceInAncestor(parentLevel, fieldName)`
-Creates a content item reference field in an ancestor page that points to the original linked content.
-
-**Parameters:**
-- `parentLevel`: Relative level of the ancestor page (-1 = direct parent, -2 = grandparent, etc.)
-- `fieldName`: Name of the content item reference field (created automatically if it doesn't exist)
-
-#### Common Strategies
-
-**Content Type-Based**: Use `NodeClassID` to look up the content type and apply different strategies based on page type.
-
-**Path-Based**: Filter by `NodeAliasPath` to handle different sections of your site (e.g., archive pages, temporary content).
-
-**Site-Specific**: Use `source.SourceSite.SiteName` to apply different rules for different sites in multi-site scenarios.
-
-**Contextual**: Combine node properties with ancestor analysis to make intelligent decisions about reference placement.
-
-#### Important Considerations
-
-1. **Field creation**: When using `StoreReferenceInAncestor`, the content item reference field is created automatically if it doesn't exist.
-
-2. **Allowed types**: If the reference field exists but doesn't allow the linked content's type, the type is automatically added to the allowed types.
-
-3. **Content hub**: For the reference strategy to work properly, ensure that the linked content types are configured as reusable content in your `appsettings.json` under `ConvertClassesToContentHub`.
-
-4. **Processing order**: Linked pages are processed using topological sorting to ensure that referenced content is migrated before the pages that reference it.
-
-5. **Cross-site links**: Links between different sites are not supported and will be skipped with a warning.
-
-#### Sample Implementation
-
-You can see a comprehensive sample implementation in [SampleLinkedPageDirector.cs](./CommunityMigrations/SampleLinkedPageDirector.cs) that demonstrates various strategies for handling linked pages based on content type, path, and site context.
-
-After implementing your linked page director, you need to [register the director](#registration) in the system.
-
-#### Troubleshooting
-
-**Common Issues:**
-- **"Ancestor not found" error**: Check that the `parentLevel` value is correct (negative values for ancestors)
-- **References not working**: Ensure the content type is in `ConvertClassesToContentHub` configuration  
-- **Deferred processing**: Some linked pages may be processed in a second pass if their dependencies aren't ready
-
-**Debugging Tips:**
-- Use logging to track which strategy is applied to each linked page
-- Verify that ancestor pages exist and have the expected structure
-
-### Customize Widget Migrations
-
-You can customize widget migration to change the widget to which source widgets are migrated in the target instance. In the `Migration.Tool.Extensions/CommunityMigrations` folder, create a new file with a class that implements the `IWidgetMigration` interface. Implement the following properties and methods required by the interface:
-
-- `Rank` - An integer property that determines the order in which migrations are applied. Use a value lower than *100000*, as that is the value for system migrations.
-- `ShallMigrate` - A boolean method that specifies whether the migration shall be applied for the current widget. Use properties of the `WidgetMigrationContext` and `WidgetIdentifier` objects passed as an argument to the method to evaluate the condition. For each widget, the migration with the lowest rank that returns `true` from the `ShallMigrate` method is used.
-  - `WidgetMigrationContext.SiteId` - An integer property that specifies the ID of the site on which the widget was used in the source instance.
-  - `WidgetIdentifier.TypeIdentifier` - A string property that specifies the identifier of the widget.
-- `MigrateWidget`- Migrate the widget data using the following properties:
-  - `identifier` - A `WidgetIdentifier` object, see `ShallMigrate` to see properties.
-  - `value` - A `JToken` object containing the deserialized value of the property.
-  - `context` - A `WidgetMigrationContext` object, see `ShallMigrate` to see properties.
-
-You can see a sample: [SampleWidgetMigration.cs](./CommunityMigrations/SampleWidgetMigration.cs)
-
-After implementing the migration, you need to [register the migration](#registration) in the system.
-
-> [!TIP]
-> For a complete end-to-end example, see our guide on [how to migrate widget data as reusable content](https://docs.kentico.com/x/migrate_widget_data_as_reusable_content_guides) in the Kentico documentation.
-
-### Customize Widget Property Migrations
-
-In the `Migration.Tool.Extensions/CommunityMigrations` folder, create a new file with a class that implements the `IWidgetPropertyMigration` interface. Implement the following properties and methods required by the interface:
-
-- `Rank` - An integer property that determines the order in which migrations are applied. Use a value lower than *100000*, as that is the value for system migrations.
-- `ShallMigrate` - A boolean method that specifies whether the migration shall be applied for the current widget. Use properties of the `WidgetPropertyMigrationContext` and `propertyName` objects passed as an argument to the method to evaluate the condition. For each widget property, the migration with the lowest rank that returns `true` from the `ShallMigrate` method is used.
-  - `WidgetPropertyMigrationContext.SiteId` - An integer property that specifies the ID of the site on which the widget was used in the source instance.
-  - `WidgetPropertyMigrationContext.EditingFormControlModel` - An object representing the [form control](https://docs.kentico.com/x/lAyRBg) of the property.
-  - `propertyName` - A string property that specifies the identifier of the property.
-- `MigrateWidgetProperty`- Migrate the widget property data using the following properties:
-  - `key` - Name of the property.
-  - `value` - A `JToken` object containing the deserialized value of the property.
-  - `context` - A `WidgetPropertyMigrationContext`. See `ShallMigrate` method to see the properties.
-
-You can see samples:
-
-- [Path selector migration](./DefaultMigrations/WidgetPathSelectorMigration.cs)
-- [Page selector migration](./DefaultMigrations/WidgetPageSelectorMigration.cs)
-- [File selector migration](./DefaultMigrations/WidgetFileMigration.cs)
-
-After implementing the migration, you need to [register the migration](#registration) in the system.
-
-> [!TIP]
-> For common widget property transformation scenarios, see [our technical deep-dive guide](https://docs.kentico.com/x/transform_widget_properties_guides) in the Kentico documentation.
-
-### Migrate Pages to Widgets
-
-This migration allows you to migrate pages from the source instance as [widgets](https://docs.kentico.com/x/7gWiCQ) in the target instance. This migration can be used in the following ways:
-
-- If you have a page with content stored in page fields, you can migrate the values of the fields into widget properties and display the content as a widget.
-- If you have a page that serves as a listing and displays content from child pages, you can convert the child pages into widgets and as content items in the content hub, then link them from the widgets.
-
-> :warning:
-> The target page (with a [Page Builder editable area](https://docs.kentico.com/x/7AWiCQ)) and any [Page Builder components](https://docs.kentico.com/x/6QWiCQ) used in the migration need to be present in the system before you migrate content. The target page must be either the page itself or any ancestor of the page from which the content is migrated.
-
-In `Migration.Tool.Extensions/CommunityMigrations`, create a new file with a class that inherits from the `ContentItemDirectorBase` class and override the `Direct(source, options)` method:
-
-1. If the target page uses a [page template](https://docs.kentico.com/x/iInWCQ), ensure that the correct page template is applied.
-
-    ```csharp
-    // Store page uses a template and is the parent listing page
-    if (source.SourceNode.SourceClassName == "Acme.Store")
-    {
-      // Ensures the page template is present in the system
-      options.OverridePageTemplate("StorePageTemplate");
-    }
-    ```
-
-2. Identify pages you want to migrate to widgets and use the `options.AsWidget()` action.
-
-    ```csharp
-    // Identifies pages by their content type
-    else if (source.SourceNode.SourceClassName == "Acme.Coffee")
-    {
-        options.AsWidget("Acme.CoffeeSampleWidget", null, null, options =>
-        {
-            // Determines where to place the widget
-            options.Location
-                // Negative indexing is used - '-1' signifies direct parent node
-                // Use the value of '0' if you want to target the page itself
-                .OnAncestorPage(-1)
-                .InEditableArea("main-area")
-                .InSection("SingleColumnSection")
-                .InFirstZone();
-
-            // Specifies the widget's properties
-            options.Properties.Fill(true, (itemProps, reusableItemGuid, childGuids) =>
-            {
-                // Simple way to achieve basic conversion of all properties, properties can be refined in the following steps
-                var widgetProps = JObject.FromObject(itemProps);
-
-                // The converted page is linked as a reusable content item into a single property of the widget.
-                // NOTE: List the page class name app settings in ConvertClassesToContentHub to make it reusable!
-                widgetProps["LinkedContent"] = LinkedItemPropertyValue(reusableItemGuid!.Value);
-
-                // Link reusable content items created from page's original subnodes
-                // NOTE: List the page class names in app settings in ConvertClassesToContentHub to make it reusable!
-                widgetProps["LinkedChildren"] = LinkedItemsPropertyValue(childGuids);
-
-                return widgetProps;
-            });
-        });
-    }
-    ```
-
-After implementing the content item director, you need to [register the director](#registration) in the system.
-
-> [!TIP]
-> You can see a sample implementation in [SamplePageToWidgetDirector.cs](./CommunityMigrations/SamplePageToWidgetDirector.cs) or follow along with our complete practical example on [how to convert child pages to widgets](https://docs.kentico.com/x/convert_child_pages_to_widgets_guides) in the Kentico documentation.
 
 ### Custom Class Mappings
 
@@ -474,6 +242,167 @@ You can find sample class mappings in the [ClassMappingSample.cs](/Migration.Too
 - `AddClassMergeSample` showcases how to merge two page types into a single content type
 - `AddReusableRemodelingSample` showcases how to migrate a page type as reusable content
 
+### Customize Linked Page Handling
+
+When migrating from Kentico versions that support [linked pages](https://docs.kentico.com/13/managing-website-content/working-with-pages/copying-and-moving-pages-creating-linked-pages#creating-linked-pages) (pages that reference content from other pages in the content tree), you need to decide how to handle them since Xperience by Kentico doesn't support linked pages in the same way.
+
+The linked pages director feature provides a flexible solution to customize how linked pages are handled during migration. You can choose to materialize linked content, drop it entirely, or store references in ancestor pages.
+
+#### Understanding Linked Pages
+
+In older Kentico versions, linked pages allowed you to create pages that displayed content from other pages without duplicating the actual content. This was useful for:
+- Sharing content across multiple sections of a website
+- Creating content references without data duplication  
+- Building complex content hierarchies
+
+#### Migration Strategies
+
+The linked pages director offers three main strategies for handling linked pages:
+
+#### 1. Materialize (Default)
+Creates a full copy of the linked content as an independent page.
+- **Use when**: You want to preserve the content structure but can accept content duplication
+- **Result**: Each linked page becomes a separate content item with its own copy of the data
+
+#### 2. Drop
+Completely skips migration of the linked page.
+- **Use when**: The linked content is no longer needed or should be handled manually
+- **Result**: The linked page will not be migrated to the target instance
+
+#### 3. Store as Reference
+Creates a content item reference field in an ancestor page that points to the original linked content.
+- **Use when**: You want to preserve the relationship without duplicating content
+- **Result**: The linked content is referenced through a content item selector field
+
+#### Implementation
+
+In `Migration.Tool.Extensions/CommunityMigrations`, create a new file with a class that inherits from the `ContentItemDirectorBase` class and override the `DirectLinkedNode(source, options)` method.
+
+The `LinkedPageSource` provides access to:
+- `source.SourceSite` - The site where the linked page exists
+- `source.SourceNode` - The node that contains the link  
+- `source.LinkedNode` - The target node being linked to
+
+Implement your decision logic based on available node properties (`NodeClassID`, `NodeAliasPath`, `NodeName`, etc.) and call the appropriate action method.
+
+#### Available Actions
+
+##### `options.Drop()`
+Skips migration of the linked page entirely. Use for temporary content, archived pages, or content that should be handled manually.
+
+#### `options.Materialize()`
+Creates an independent copy of the linked content (default behavior). This preserves the content structure but results in content duplication.
+
+#### `options.StoreReferenceInAncestor(parentLevel, fieldName)`
+Creates a content item reference field in an ancestor page that points to the original linked content.
+
+**Parameters:**
+- `parentLevel`: Relative level of the ancestor page (-1 = direct parent, -2 = grandparent, etc.)
+- `fieldName`: Name of the content item reference field (created automatically if it doesn't exist)
+
+#### Common Strategies
+
+**Content Type-Based**: Use `NodeClassID` to look up the content type and apply different strategies based on page type.
+
+**Path-Based**: Filter by `NodeAliasPath` to handle different sections of your site (e.g., archive pages, temporary content).
+
+**Site-Specific**: Use `source.SourceSite.SiteName` to apply different rules for different sites in multi-site scenarios.
+
+**Contextual**: Combine node properties with ancestor analysis to make intelligent decisions about reference placement.
+
+#### Important Considerations
+
+1. **Field creation**: When using `StoreReferenceInAncestor`, the content item reference field is created automatically if it doesn't exist.
+
+2. **Allowed types**: If the reference field exists but doesn't allow the linked content's type, the type is automatically added to the allowed types.
+
+3. **Content hub**: For the reference strategy to work properly, ensure that the linked content types are configured as reusable content in your `appsettings.json` under `ConvertClassesToContentHub`.
+
+4. **Processing order**: Linked pages are processed using topological sorting to ensure that referenced content is migrated before the pages that reference it.
+
+5. **Cross-site links**: Links between different sites are not supported and will be skipped with a warning.
+
+#### Sample Implementation
+
+You can see a comprehensive sample implementation in [SampleLinkedPageDirector.cs](./CommunityMigrations/SampleLinkedPageDirector.cs) that demonstrates various strategies for handling linked pages based on content type, path, and site context.
+
+After implementing your linked page director, you need to [register the director](#registration) in the system.
+
+#### Troubleshooting
+
+**Common Issues:**
+- **"Ancestor not found" error**: Check that the `parentLevel` value is correct (negative values for ancestors)
+- **References not working**: Ensure the content type is in `ConvertClassesToContentHub` configuration  
+- **Deferred processing**: Some linked pages may be processed in a second pass if their dependencies aren't ready
+
+**Debugging Tips:**
+- Use logging to track which strategy is applied to each linked page
+- Verify that ancestor pages exist and have the expected structure
+
+### Migrate Pages to Widgets
+
+This migration allows you to migrate pages from the source instance as [widgets](https://docs.kentico.com/x/7gWiCQ) in the target instance. This migration can be used in the following ways:
+
+- If you have a page with content stored in page fields, you can migrate the values of the fields into widget properties and display the content as a widget.
+- If you have a page that serves as a listing and displays content from child pages, you can convert the child pages into widgets and as content items in the content hub, then link them from the widgets.
+
+> :warning:
+> The target page (with a [Page Builder editable area](https://docs.kentico.com/x/7AWiCQ)) and any [Page Builder components](https://docs.kentico.com/x/6QWiCQ) used in the migration need to be present in the system before you migrate content. The target page must be either the page itself or any ancestor of the page from which the content is migrated.
+
+In `Migration.Tool.Extensions/CommunityMigrations`, create a new file with a class that inherits from the `ContentItemDirectorBase` class and override the `Direct(source, options)` method:
+
+1. If the target page uses a [page template](https://docs.kentico.com/x/iInWCQ), ensure that the correct page template is applied.
+
+    ```csharp
+    // Store page uses a template and is the parent listing page
+    if (source.SourceNode.SourceClassName == "Acme.Store")
+    {
+      // Ensures the page template is present in the system
+      options.OverridePageTemplate("StorePageTemplate");
+    }
+    ```
+
+2. Identify pages you want to migrate to widgets and use the `options.AsWidget()` action.
+
+    ```csharp
+    // Identifies pages by their content type
+    else if (source.SourceNode.SourceClassName == "Acme.Coffee")
+    {
+        options.AsWidget("Acme.CoffeeSampleWidget", null, null, options =>
+        {
+            // Determines where to place the widget
+            options.Location
+                // Negative indexing is used - '-1' signifies direct parent node
+                // Use the value of '0' if you want to target the page itself
+                .OnAncestorPage(-1)
+                .InEditableArea("main-area")
+                .InSection("SingleColumnSection")
+                .InFirstZone();
+
+            // Specifies the widget's properties
+            options.Properties.Fill(true, (itemProps, reusableItemGuid, childGuids) =>
+            {
+                // Simple way to achieve basic conversion of all properties, properties can be refined in the following steps
+                var widgetProps = JObject.FromObject(itemProps);
+
+                // The converted page is linked as a reusable content item into a single property of the widget.
+                // NOTE: List the page class name app settings in ConvertClassesToContentHub to make it reusable!
+                widgetProps["LinkedContent"] = LinkedItemPropertyValue(reusableItemGuid!.Value);
+
+                // Link reusable content items created from page's original subnodes
+                // NOTE: List the page class names in app settings in ConvertClassesToContentHub to make it reusable!
+                widgetProps["LinkedChildren"] = LinkedItemsPropertyValue(childGuids);
+
+                return widgetProps;
+            });
+        });
+    }
+    ```
+
+After implementing the content item director, you need to [register the director](#registration) in the system.
+
+> [!TIP]
+> You can see a sample implementation in [SamplePageToWidgetDirector.cs](./CommunityMigrations/SamplePageToWidgetDirector.cs) or follow along with our complete practical example on [how to convert child pages to widgets](https://docs.kentico.com/x/convert_child_pages_to_widgets_guides) in the Kentico documentation.
 
 ### Custom Child Links
 
@@ -484,6 +413,73 @@ This feature is available by means of content item director.
 You can apply a simple general rule to link child pages e.g. in `Children` field or you can apply more elaborate rules. You can see samples of both approaches in [SampleChildLinkDirector.cs](./CommunityMigrations/SampleChildLinkDirector.cs) or follow along with our [guide to transfer page hierarchy to the Content hub](https://docs.kentico.com/x/transfer_page_hierarchy_to_content_hub_guides).
 
 After implementing the content item director, you need to [register the director](#registration) in the system.
+
+### Customize Field Migrations
+
+You can customize field migrations to control how fields are mapped for page types, modules, system objects, and forms. In the `Migration.Tool.Extensions/CommunityMigrations` folder, create a new file with a class that implements the `IFieldMigration` interface. Implement the following properties and methods required by the interface:
+
+- `Rank` - An integer property that determines the order in which migrations are applied. Use a value lower than *100000*, as that is the value for system migrations.
+- `ShallMigrate` - A boolean method that specifies whether the migration shall be applied for the current field. Use properties of the `FieldMigrationContext` object passed as an argument to the method to evaluate the condition. For each field, the migration with the lowest rank that returns `true` from the `ShallMigrate` method is used.
+  - `SourceDataType` - A string property that specifies the [data type](https://docs.kentico.com/x/coJwCg) of the source field.
+  - `SourceFormControl` - A string property that specifies the [form control](https://docs.kentico.com/x/lAyRBg) used by the source field.
+  - `FieldName` - A string property that specifies the code name of the field.
+  - `SourceObjectContext` - An interface that can be used to check the context of the source object (e.g. page vs. form).
+- `MigrateFieldDefinition` - Migrate the definition of the field. Use the `XElement` attribute to transform the field.
+- `MigrateValue` - Migrate the value of the field. Use the source value and the `FieldMigrationContext` with the same parameters as described in `ShallMigrate`.
+
+You can see samples:
+
+- [SampleTextMigration.cs](./CommunityMigrations/SampleTextMigration.cs)
+  - A sample migration with further explanations
+- [AssetMigration.cs](./DefaultMigrations/AssetMigration.cs)
+  - An example of a usable migration
+
+After implementing the migration, you need to [register the migration](#registration) in the system.
+
+### Customize Widget Migrations
+
+You can customize widget migration to change the widget to which source widgets are migrated in the target instance. In the `Migration.Tool.Extensions/CommunityMigrations` folder, create a new file with a class that implements the `IWidgetMigration` interface. Implement the following properties and methods required by the interface:
+
+- `Rank` - An integer property that determines the order in which migrations are applied. Use a value lower than *100000*, as that is the value for system migrations.
+- `ShallMigrate` - A boolean method that specifies whether the migration shall be applied for the current widget. Use properties of the `WidgetMigrationContext` and `WidgetIdentifier` objects passed as an argument to the method to evaluate the condition. For each widget, the migration with the lowest rank that returns `true` from the `ShallMigrate` method is used.
+  - `WidgetMigrationContext.SiteId` - An integer property that specifies the ID of the site on which the widget was used in the source instance.
+  - `WidgetIdentifier.TypeIdentifier` - A string property that specifies the identifier of the widget.
+- `MigrateWidget`- Migrate the widget data using the following properties:
+  - `identifier` - A `WidgetIdentifier` object, see `ShallMigrate` to see properties.
+  - `value` - A `JToken` object containing the deserialized value of the property.
+  - `context` - A `WidgetMigrationContext` object, see `ShallMigrate` to see properties.
+
+You can see a sample: [SampleWidgetMigration.cs](./CommunityMigrations/SampleWidgetMigration.cs)
+
+After implementing the migration, you need to [register the migration](#registration) in the system.
+
+> [!TIP]
+> For a complete end-to-end example, see our guide on [how to migrate widget data as reusable content](https://docs.kentico.com/x/migrate_widget_data_as_reusable_content_guides) in the Kentico documentation.
+
+### Customize Widget Property Migrations
+
+In the `Migration.Tool.Extensions/CommunityMigrations` folder, create a new file with a class that implements the `IWidgetPropertyMigration` interface. Implement the following properties and methods required by the interface:
+
+- `Rank` - An integer property that determines the order in which migrations are applied. Use a value lower than *100000*, as that is the value for system migrations.
+- `ShallMigrate` - A boolean method that specifies whether the migration shall be applied for the current widget. Use properties of the `WidgetPropertyMigrationContext` and `propertyName` objects passed as an argument to the method to evaluate the condition. For each widget property, the migration with the lowest rank that returns `true` from the `ShallMigrate` method is used.
+  - `WidgetPropertyMigrationContext.SiteId` - An integer property that specifies the ID of the site on which the widget was used in the source instance.
+  - `WidgetPropertyMigrationContext.EditingFormControlModel` - An object representing the [form control](https://docs.kentico.com/x/lAyRBg) of the property.
+  - `propertyName` - A string property that specifies the identifier of the property.
+- `MigrateWidgetProperty`- Migrate the widget property data using the following properties:
+  - `key` - Name of the property.
+  - `value` - A `JToken` object containing the deserialized value of the property.
+  - `context` - A `WidgetPropertyMigrationContext`. See `ShallMigrate` method to see the properties.
+
+You can see samples:
+
+- [Path selector migration](./DefaultMigrations/WidgetPathSelectorMigration.cs)
+- [Page selector migration](./DefaultMigrations/WidgetPageSelectorMigration.cs)
+- [File selector migration](./DefaultMigrations/WidgetFileMigration.cs)
+
+After implementing the migration, you need to [register the migration](#registration) in the system.
+
+> [!TIP]
+> For common widget property transformation scenarios, see [our technical deep-dive guide](https://docs.kentico.com/x/transform_widget_properties_guides) in the Kentico documentation.
 
 ## Registration
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains the data migration tool and its technical reference doc
 - [Advanced upgrade deep dives](https://docs.kentico.com/x/upgrade_deep_dives_guides) - Developer-focused guides for customizing migrations and handling complex scenarios
 
 > [!IMPORTANT]
-> When planning an upgrade, note special considerations for [deploying to production](https://docs.kentico.com/guides/architecture/upgrade-from-kx13/upgrade-faq#are-there-special-considerations-when-deploying-an-upgraded-project-to-production-for-the-first-time) and [deploying to SaaS](https://docs.kentico.com/guides/architecture/upgrade-from-kx13/upgrade-faq#are-there-special-considerations-when-performing-an-upgrade-using-xperience-by-kentico-saas).
+> When planning an upgrade, note special considerations for [deploying to production](https://docs.kentico.com/guides/upgrade-to-xbyk/upgrade-from-kx13/upgrade-faq#are-there-special-considerations-when-deploying-an-upgraded-project-to-production-for-the-first-time) and [deploying to SaaS](https://docs.kentico.com/guides/upgrade-to-xbyk/upgrade-from-kx13/upgrade-faq#are-there-special-considerations-when-performing-an-upgrade-using-xperience-by-kentico-saas).
 
 ## Technical Documentation (This Repository)
 
@@ -182,7 +182,7 @@ To report bugs, upgrade to the latest Migration Tool version before submitting i
 See [`SUPPORT.md`](https://github.com/Kentico/.github/blob/main/SUPPORT.md#full-support) for more information.
 
 > [!IMPORTANT]
-> Before submitting a support ticket, please read about the [best practices on reporting Kentico Migration Tool and upgrade issues](https://docs.kentico.com/guides/architecture/upgrade-from-kx13/upgrade-faq#what-is-the-difference-between-the-documentation-in-the-github-repo-and-on-the-docs.kentico.com-site).
+> Before submitting a support ticket, please read about the [best practices on reporting Kentico Migration Tool and upgrade issues](https://docs.kentico.com/guides/upgrade-to-xbyk/upgrade-from-kx13/upgrade-faq#what-is-the-difference-between-the-documentation-in-the-github-repo-and-on-the-docs.kentico.com-site).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For a lift-and-shift migration, use the migration tool's default configuration:
    --sites --custom-modules --users --settings-keys --page-types --pages --type-restrictions --contact-management --forms --media-libraries --data-protection --custom-tables --members --categories
    ```
 
-5. **Review results** - Check console output and log files for issues or manual steps:
+5. **Review results** - Check console [output and log files](./Migration.Tool.CLI/README.md#logging) for issues or manual steps:
    - **Console** shows real-time progress and results
    - **Log files** capture detailed execution logs (`logs\log-<date>.txt`)
 


### PR DESCRIPTION
### Motivation

Update the non-permalinks to the Learn Portal.
Remove leftover migration protocol (obsolete) mentions in examples.
Improve Migration.Tool.Extensions README documentation:
- Add note clarifying widget migration timing relative to database persistence
- Reorganize customization type sections to follow execution order for consistency throughout the document.