### PR TITLE
Media files migration fix

### DIFF
--- a/KVA/Migration.Tool.Source/Services/AssetFacade.cs
+++ b/KVA/Migration.Tool.Source/Services/AssetFacade.cs
@@ -477,7 +477,7 @@ public class AssetFacade(
                 !string.IsNullOrWhiteSpace(toolConfiguration.KxCmsDirPath))
         {
             var pathParts = new List<string>();
-            if (cmsMediaLibrariesFolder != null)
+            if (!string.IsNullOrEmpty(cmsMediaLibrariesFolder))
             {
                 if (Path.IsPathRooted(cmsMediaLibrariesFolder))
                 {


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #601 

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

- Go to Settings -> Content -> Media
- Switch site from (global) to DancingGoatCore
- Put white space to the 'Media libraries folder' field and hit the Save
- Check in DB that CMSMediaLibrariesFolder for the DancingGoatCore site contains the empty string
- Migrate data
- Check log (no media files migration errors) and that media files are correctly migrated 

`select * from CMS_SettingsKey where keyname = 'CMSMediaLibrariesFolder'`

<img width="2085" height="1035" alt="image" src="https://github.com/user-attachments/assets/db06b9ed-71c7-47c7-a4cb-50091ab4d3bb" />
