### PR TITLE
Document configuration keys, and how to handle CMSForbiddenURLValues

### DIFF
--- a/docs/Supported-Data.md
+++ b/docs/Supported-Data.md
@@ -103,6 +103,8 @@ Currently, the Kentico Migration Tool supports the following types of data:
 ### Setting values
 - The migration only transfers the settings that exist in Xperience by Kentico.
 - The migration excludes site-specific settings that do not have a corresponding website channel-specific alternative in Xperience by Kentico.
+- The migration does not transfer settings configured in application files, like **web.config** and **appsettings.json**. Manually move these setting values to the corresponding settings in the Xperience by Kentico admin UI where possible, and set applicable [configuration keys](https://docs.kentico.com/x/JQKQC) when no admin setting is available.
+  - In the case of `CMSForbiddenURLValues`, we specifically recommend migrating its value to the `CMSForbiddenURLCharacters` setting, to avoid issues with migrated URLs during content sync.
 
 ### Customers
   - Migration of customers is only available for Kentico Xperience 13.


### PR DESCRIPTION


### Motivation

Addresses the issue reported internally through XDHD-1322, mentioning configuration keys and how to handle the CMSForbiddenUrlValues config key

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults