### PR TITLE
HtmlProcessor - fixes for unsupported links plus content item directors

### DIFF
--- a/KVA/Migration.Tool.Source/Handlers/MigratePagesCommandHandler.cs
+++ b/KVA/Migration.Tool.Source/Handlers/MigratePagesCommandHandler.cs
@@ -417,13 +417,11 @@ public class MigratePagesCommandHandler(
                             }
                         }
 
-                        var targetClassInfo = contentItemDirective!.TargetClassInfo;
-
                         if (contentItemDirective is not DropDirective)
                         {
                             AssertVersionStatusRule(commonDataInfos);
 
-                            if (webPageItemInfo != null && targetClassInfo is { ClassWebPageHasUrl: true })
+                            if (contentItemDirective != null && webPageItemInfo != null && contentItemDirective.TargetClassInfo is { ClassWebPageHasUrl: true })
                             {
                                 await GenerateDefaultPageUrlPath(ksNode, webPageItemInfo);
                                 if (!contentItemDirective!.RegenerateUrlPath)

--- a/KVA/Migration.Tool.Source/Mappers/CmsClassMapper.cs
+++ b/KVA/Migration.Tool.Source/Mappers/CmsClassMapper.cs
@@ -172,7 +172,7 @@ public class CmsClassMapper(
                     target.ClassType = ClassType.OTHER;
                     target.ClassContentTypeType = null;
                 }
-                target = PatchDataClassInfo(target, existingFieldGUIDs, modelFacade.SelectVersion(), [], IncludedMetadata.None, out string? oldPrimaryKeyName, out string? documentNameField);
+                target = PatchDataClassInfo(target, existingFieldGUIDs, modelFacade.SelectVersion(), IncludedMetadata.None, out string? oldPrimaryKeyName, out string? documentNameField);
 
                 break;
             }
@@ -206,7 +206,7 @@ public class CmsClassMapper(
                 target.ClassType = ClassType.CONTENT_TYPE;
                 target.ClassContentTypeType = ClassContentTypeType.REUSABLE;
 
-                target = PatchDataClassInfo(target, existingFieldGUIDs, modelFacade.SelectVersion(), [], configuration.IncludeExtendedMetadata.GetValueOrDefault(false) ? IncludedMetadata.Extended : IncludedMetadata.Basic, out string? oldPrimaryKeyName, out string? documentNameField);
+                target = PatchDataClassInfo(target, existingFieldGUIDs, modelFacade.SelectVersion(), configuration.IncludeExtendedMetadata.GetValueOrDefault(false) ? IncludedMetadata.Extended : IncludedMetadata.Basic, out string? oldPrimaryKeyName, out string? documentNameField);
                 break;
             }
 
@@ -224,7 +224,7 @@ public class CmsClassMapper(
                     ? ClassContentTypeType.REUSABLE
                     : ClassContentTypeType.WEBSITE;
 
-                target = PatchDataClassInfo(target, existingFieldGUIDs, modelFacade.SelectVersion(), [], configuration.IncludeExtendedMetadata.GetValueOrDefault(false) ? IncludedMetadata.Extended : IncludedMetadata.Basic, out string? oldPrimaryKeyName, out string? documentNameField);
+                target = PatchDataClassInfo(target, existingFieldGUIDs, modelFacade.SelectVersion(), configuration.IncludeExtendedMetadata.GetValueOrDefault(false) ? IncludedMetadata.Extended : IncludedMetadata.Basic, out string? oldPrimaryKeyName, out string? documentNameField);
                 break;
             }
 
@@ -268,7 +268,7 @@ public class CmsClassMapper(
         Extended
     }
 
-    public static DataClassInfo PatchDataClassInfo(DataClassInfo dataClass, Dictionary<string, Guid> existingFieldGUIDs, SemanticVersion version, Dictionary<Guid, string> reusableSchemaNames, IncludedMetadata includedMetadata, out string? oldPrimaryKeyName, out string? mappedLegacyField)
+    public static DataClassInfo PatchDataClassInfo(DataClassInfo dataClass, Dictionary<string, Guid> existingFieldGUIDs, SemanticVersion version, IncludedMetadata includedMetadata, out string? oldPrimaryKeyName, out string? mappedLegacyField)
     {
         oldPrimaryKeyName = null;
         mappedLegacyField = null;
@@ -299,7 +299,7 @@ public class CmsClassMapper(
 
             foreach (var dataDefinitionItem in fi.GetFormElements(true, true) ?? [])
             {
-                if (!nfi.ItemsList.Any(x => IsSameFormElement(reusableSchemaNames, dataDefinitionItem, x)))
+                if (!nfi.ItemsList.Any(x => IsSameFormElement(dataDefinitionItem, x)))
                 {
                     if (dataDefinitionItem is FormFieldInfo ffi)
                     {
@@ -337,7 +337,7 @@ public class CmsClassMapper(
 
             foreach (var field in GetLegacyMetadataFields(version, includedMetadata))
             {
-                AppendLegacyMetadataField(nfi, dataClass.ClassName, field, reusableSchemaNames, out mappedLegacyField);
+                AppendLegacyMetadataField(nfi, dataClass.ClassName, field, out mappedLegacyField);
             }
             dataClass.ClassFormDefinition = nfi.GetXmlDefinition();
 
@@ -377,7 +377,7 @@ public class CmsClassMapper(
         return null;
     }
 
-    private static void AppendLegacyMetadataField(FormInfo nfi, string newClassName, LegacyDocumentMetadataFieldMapping mapping, Dictionary<Guid, string> reusableSchemaNames, out string targetFieldName)
+    private static void AppendLegacyMetadataField(FormInfo nfi, string newClassName, LegacyDocumentMetadataFieldMapping mapping, out string targetFieldName)
     {
         if (GetMappedLegacyField(nfi, newClassName, mapping.LegacyFieldName) is { } fieldName)
         {
@@ -394,7 +394,7 @@ public class CmsClassMapper(
 
         var formFieldInfo = GetLegacyMetadataFormFieldInfo(mapping, targetFieldName, newClassName);
 
-        if (!nfi.ItemsList.Any(x => IsSameFormElement(reusableSchemaNames, formFieldInfo, x)))
+        if (!nfi.ItemsList.Any(x => IsSameFormElement(formFieldInfo, x)))
         {
             nfi.AddFormItem(formFieldInfo);
         }
@@ -415,7 +415,7 @@ public class CmsClassMapper(
     };
 
 
-    private static bool IsSameFormElement(Dictionary<Guid, string> reusableSchemaNames, IDataDefinitionItem element1, IDataDefinitionItem element2)
+    private static bool IsSameFormElement(IDataDefinitionItem element1, IDataDefinitionItem element2)
     {
         if (element1 is FormFieldInfo ffi1 && element2 is FormFieldInfo ffi2)
         {
@@ -423,9 +423,7 @@ public class CmsClassMapper(
         }
         else if (element1 is FormSchemaInfo fsi1 && element2 is FormSchemaInfo fsi2)
         {
-            return reusableSchemaNames.TryGetValue(fsi1.Guid, out string? schemaName1) &&
-                reusableSchemaNames.TryGetValue(fsi2.Guid, out string? schemaName2) &&
-                schemaName1.Equals(schemaName2, StringComparison.InvariantCultureIgnoreCase);
+            return fsi1.Guid == fsi2.Guid;
         }
         else
         {

--- a/KVA/Migration.Tool.Source/Mappers/ContentItemMapper.cs
+++ b/KVA/Migration.Tool.Source/Mappers/ContentItemMapper.cs
@@ -633,12 +633,17 @@ public class ContentItemMapper(
         {
             director.MediaInfoLoader = new Func<Guid, JToken>(LoadMediaInfo);
             director.Direct(contentItemSource, directiveFacade);
-            if (directiveFacade.Directive is not null)
+            if (directiveFacade.Directive is DropDirective)
             {
                 break;
             }
         }
-        directiveFacade.Directive!.FormerUrlPaths ??= contentItemSource.FormerUrlPaths;
+
+        if (directiveFacade.Directive is not DropDirective)
+        {
+            directiveFacade.Directive!.FormerUrlPaths ??= contentItemSource.FormerUrlPaths;
+        }
+
         return directiveFacade.Directive!;
     }
 

--- a/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
+++ b/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
@@ -120,13 +120,6 @@ public class ClassMappingProvider(
 
             newDt.ClassFormDefinition = nfi.GetXmlDefinition();
 
-            var reusableSchemas = new Dictionary<Guid, string>();
-            foreach (string schemaName in classMapping.ReusableSchemaNames)
-            {
-                Guid schemaGuid = reusableSchemaService.AddReusableSchemaToDataClass(newDt, schemaName);
-                reusableSchemas[schemaGuid] = schemaName;
-            }
-
             nfi = new FormInfo(newDt.ClassFormDefinition);
 
             var fieldInReusableSchemas = reusableSchemaService.GetFieldsFromReusableSchema(newDt).ToDictionary(x => x.Name, x => x);
@@ -172,7 +165,7 @@ public class ClassMappingProvider(
 
             var includedMetadata = cmsClasses.Any(x => x.ClassResourceID.HasValue) ? IncludedMetadata.None : (configuration.IncludeExtendedMetadata.GetValueOrDefault(false) ? IncludedMetadata.Extended : IncludedMetadata.Basic);
             FormDefinitionHelper.MapFormDefinitionFields(logger, fieldMigrationService, nfi.GetXmlDefinition(), false, true, newDt, false, false, new FormInfo(newDt.ClassFormDefinition).GetFormElements(true, true).Select(x => GetFormElementName(x)));
-            PatchDataClassInfo(newDt, [], modelFacade.SelectVersion(), reusableSchemas, includedMetadata, out _, out _);
+            PatchDataClassInfo(newDt, [], modelFacade.SelectVersion(), includedMetadata, out _, out _);
 
             if (classMapping.TargetFieldPatchers.Count > 0)
             {

--- a/KVA/Migration.Tool.Source/Services/MediaFileMigratorToContentItem.cs
+++ b/KVA/Migration.Tool.Source/Services/MediaFileMigratorToContentItem.cs
@@ -99,7 +99,7 @@ public class MediaFileMigratorToContentItem(
         foreach (var director in directors)
         {
             director.Direct(contentItemSource, directiveFacade);
-            if (directiveFacade.Directive is not null)
+            if (directiveFacade.Directive is DropDirective)
             {
                 break;
             }

--- a/Migration.Tool.Common/Helpers/HtmlProcessor.cs
+++ b/Migration.Tool.Common/Helpers/HtmlProcessor.cs
@@ -54,9 +54,9 @@ public class HtmlProcessor
                         changed = true;
                     }
                 }
-                catch (UriFormatException)
+                catch (Exception)
                 {
-                    // Malformed URI in source HTML - skip this link and preserve the original value
+                    // Unsupported/malformed URI in source HTML or other type of error during link conversion - skip this link and preserve the original value
                 }
             }
         }

--- a/Migration.Tool.Common/Helpers/HtmlProcessor.cs
+++ b/Migration.Tool.Common/Helpers/HtmlProcessor.cs
@@ -43,13 +43,20 @@ public class HtmlProcessor
         {
             if (node?.Attributes[attributeName].Value is { } src)
             {
-                var matchedLink = mediaLinkService.MatchMediaLink(src, currentSiteId);
-                var newValue = await TransformMediaLink(matchedLink, src, linkType, mediaLinkTransformer);
-
-                if (newValue != src)
+                try
                 {
-                    node.Attributes[attributeName].Value = newValue;
-                    changed = true;
+                    var matchedLink = mediaLinkService.MatchMediaLink(src, currentSiteId);
+                    var newValue = await TransformMediaLink(matchedLink, src, linkType, mediaLinkTransformer);
+
+                    if (newValue != src)
+                    {
+                        node.Attributes[attributeName].Value = newValue;
+                        changed = true;
+                    }
+                }
+                catch (UriFormatException)
+                {
+                    // Malformed URI in source HTML - skip this link and preserve the original value
                 }
             }
         }

--- a/Migration.Tool.Tests/HtmlProcessorTests.cs
+++ b/Migration.Tool.Tests/HtmlProcessorTests.cs
@@ -201,6 +201,153 @@ public class HtmlProcessorTests
         });
     }
 
+    [Theory]
+    [InlineData("mailto:user@example.com")]
+    [InlineData("mailto:support@kentico.com?subject=Hello&body=World")]
+    public async Task ProcessHtml_PreservesMailtoHref_AndDoesNotInvokeTransformer(string href)
+    {
+        var mediaLinkService = new MediaLinkService(
+            [(2, "MTExtensibilityTests", "https://localhost:51157/Kentico13_2024_DG_Extensibility")],
+            [],
+            [(2, "True")],
+            new Dictionary<int, HashSet<string>>()
+        );
+
+        var html = $"""<a href="{href}">Contact</a>""";
+        var processor = new HtmlProcessor(html, mediaLinkService);
+
+        var transformerInvoked = false;
+        var result = await processor.ProcessHtml(2, (match, originalUrl) =>
+        {
+            transformerInvoked = true;
+            return Task.FromResult(originalUrl);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.False(transformerInvoked, "Transformer should not be invoked for mailto links");
+            Assert.Contains(href, result);
+        });
+    }
+
+    [Theory]
+    [InlineData("javascript:void(0)")]
+    [InlineData("javascript:alert('xss')")]
+    public async Task ProcessHtml_PreservesJavascriptHref_AndDoesNotInvokeTransformer(string href)
+    {
+        var mediaLinkService = new MediaLinkService(
+            [(2, "MTExtensibilityTests", "https://localhost:51157/Kentico13_2024_DG_Extensibility")],
+            [],
+            [(2, "True")],
+            new Dictionary<int, HashSet<string>>()
+        );
+
+        var html = $"""<a href="{href}">Click</a>""";
+        var processor = new HtmlProcessor(html, mediaLinkService);
+
+        var transformerInvoked = false;
+        var result = await processor.ProcessHtml(2, (match, originalUrl) =>
+        {
+            transformerInvoked = true;
+            return Task.FromResult(originalUrl);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.False(transformerInvoked, "Transformer should not be invoked for javascript links");
+            Assert.Contains(href, result);
+        });
+    }
+
+    [Theory]
+    [InlineData(":::malformed:::")]
+    [InlineData("http://[invalid-ipv6")]
+    [InlineData("%gg-not-valid-percent-encoding")]
+    public async Task ProcessHtml_DoesNotThrow_ForMalformedHref(string href)
+    {
+        var mediaLinkService = new MediaLinkService(
+            [(2, "MTExtensibilityTests", "https://localhost:51157/Kentico13_2024_DG_Extensibility")],
+            [],
+            [(2, "True")],
+            new Dictionary<int, HashSet<string>>()
+        );
+
+        var html = $"""<a href="{href}">Link</a>""";
+        var processor = new HtmlProcessor(html, mediaLinkService);
+
+        var transformerInvoked = false;
+        var exception = await Record.ExceptionAsync(() => processor.ProcessHtml(2, (match, originalUrl) =>
+        {
+            transformerInvoked = true;
+            return Task.FromResult(originalUrl);
+        }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Null(exception);
+            Assert.False(transformerInvoked, "Transformer should not be invoked for malformed links");
+        });
+    }
+
+    [Theory]
+    [InlineData(":::malformed:::")]
+    [InlineData("%gg-not-valid-percent-encoding")]
+    public async Task ProcessHtml_DoesNotThrow_ForMalformedImgSrc(string src)
+    {
+        var mediaLinkService = new MediaLinkService(
+            [(2, "MTExtensibilityTests", "https://localhost:51157/Kentico13_2024_DG_Extensibility")],
+            [],
+            [(2, "True")],
+            new Dictionary<int, HashSet<string>>()
+        );
+
+        var html = $"""<img src="{src}" alt="broken" />""";
+        var processor = new HtmlProcessor(html, mediaLinkService);
+
+        var transformerInvoked = false;
+        var exception = await Record.ExceptionAsync(() => processor.ProcessHtml(2, (match, originalUrl) =>
+        {
+            transformerInvoked = true;
+            return Task.FromResult(originalUrl);
+        }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Null(exception);
+            Assert.False(transformerInvoked, "Transformer should not be invoked for malformed img src");
+        });
+    }
+
+    [Theory]
+    [InlineData("#anchor-only")]
+    [InlineData("?query=only")]
+    [InlineData("")]
+    public async Task ProcessHtml_PreservesLegacyOrRelativeHref_AndDoesNotInvokeTransformer(string href)
+    {
+        var mediaLinkService = new MediaLinkService(
+            [(2, "MTExtensibilityTests", "https://localhost:51157/Kentico13_2024_DG_Extensibility")],
+            [],
+            [(2, "True")],
+            new Dictionary<int, HashSet<string>>()
+        );
+
+        var html = $"""<a href="{href}">Legacy link</a>""";
+        var processor = new HtmlProcessor(html, mediaLinkService);
+
+        var transformerInvoked = false;
+        var result = await processor.ProcessHtml(2, (match, originalUrl) =>
+        {
+            transformerInvoked = true;
+            return Task.FromResult(originalUrl);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.False(transformerInvoked, "Transformer should not be invoked for anchor/query-only/empty links");
+            Assert.Contains(href, result);
+        });
+    }
+
     [Fact]
     public async Task ProcessHtml_HandlesDirectMediaPath()
     {


### PR DESCRIPTION
### Motivation

Fixes #605, #613 and #617 

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

### HtmlProcessor

- Migrate pages with hyperlinks like: mailto:... , javascript:... etc.
- Check event log that there are no issues/warnings
- Check migrated pages - links should be migrated as they are

### Directors

- Create at least 2 content item directors (parent ContentItemDirectorBase) and register them in ServiceCollectionExtensions
- Override the Direct method of the first director to return Drop/Passthrough directive
- Check that the second director is not called when the first one returns the Drop directive 
- Check that the second director is called when the first one returns the Passthrough directive 

### Taxonomies

See the Repro steps of the issue https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/issues/617
