### PR TITLE
Assigning reusable schemas to content types - fix

### DIFF
--- a/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
+++ b/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
@@ -120,6 +120,11 @@ public class ClassMappingProvider(
 
             newDt.ClassFormDefinition = nfi.GetXmlDefinition();
 
+            foreach (string schemaName in classMapping.ReusableSchemaNames)
+            {
+                reusableSchemaService.AddReusableSchemaToDataClass(newDt, schemaName);
+            }
+
             nfi = new FormInfo(newDt.ClassFormDefinition);
 
             var fieldInReusableSchemas = reusableSchemaService.GetFieldsFromReusableSchema(newDt).ToDictionary(x => x.Name, x => x);

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -592,8 +592,9 @@ public static class ClassMappingSample
 
         // declare that we intend to use reusable schema and set mappings to new fields from old ones
         m.UseReusableSchema("DancingGoatCore.ArticleBase");
-        m.BuildField("ArticleTitle").SetFrom("DancingGoatCore.Article", "ArticleTitle", true);
-        m.BuildField("ArticleTeaser").SetFrom("DancingGoatCore.Article", "ArticleTeaser", true);
+        // we have to use new field names to avoid name collisions with fields from reusable field schema
+        m.BuildField("Title").SetFrom("DancingGoatCore.Article", "ArticleTitle", true).WithFieldPatch(f => f.Caption = "Article Title");
+        m.BuildField("Teaser").SetFrom("DancingGoatCore.Article", "ArticleTeaser", true).WithFieldPatch(f => f.Caption = "Article Teaser");
 
         // register mapping
         serviceCollection.AddSingleton<IClassMapping>(m);


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #628 

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

- Use K13 DancingGoatCore site
- Go to the ServiceCollectionExtensions.cs, uncomment the following line/code: `services.AddReusableSchemaAutoGenerationSample()`
- Run migration
- Check that CMS.DataEngine.InfoObjectException is not thrown
