### PR TITLE
Adding a reusable schema to data class - class form definition fix

### DIFF
--- a/KVA/Migration.Tool.Source/Services/ReusableSchemaService.cs
+++ b/KVA/Migration.Tool.Source/Services/ReusableSchemaService.cs
@@ -67,7 +67,7 @@ public class ReusableSchemaService(ILogger<ReusableSchemaService> logger, ToolCo
             formInfo.RemoveFormField(formFieldInfo.Name);
         }
 
-        formInfo.AddFormItem(new FormSchemaInfo { Name = rfsName, Guid = reusableSchemaGuid });
+        formInfo.AddFormItem(new FormSchemaInfo { Name = reusableSchemaGuid.ToString(), Guid = reusableSchemaGuid });
         kxoDataClass.ClassFormDefinition = formInfo.GetXmlDefinition();
         return kxoDataClass;
     }
@@ -102,9 +102,10 @@ public class ReusableSchemaService(ILogger<ReusableSchemaService> logger, ToolCo
     public IEnumerable<FormFieldInfo> GetFieldsFromReusableSchema(DataClassInfo dataClassInfo)
     {
         var formInfo = new FormInfo(dataClassInfo.ClassFormDefinition);
-        foreach (var formSchemaInfo in formInfo.GetFields<FormSchemaInfo>())
+        foreach (var formSchemaItem in formInfo.GetFields<FormSchemaInfo>())
         {
-            foreach (var formFieldInfo in reusableFieldSchemaManager.GetSchemaFields(formSchemaInfo.Name))
+            var schema = reusableFieldSchemaManager.Get(formSchemaItem.Guid);
+            foreach (var formFieldInfo in reusableFieldSchemaManager.GetSchemaFields(schema.Name))
             {
                 yield return formFieldInfo;
             }

--- a/KVA/Migration.Tool.Source/Services/ReusableSchemaService.cs
+++ b/KVA/Migration.Tool.Source/Services/ReusableSchemaService.cs
@@ -83,8 +83,7 @@ public class ReusableSchemaService(ILogger<ReusableSchemaService> logger, ToolCo
     public void AddReusableSchemaToDataClass(DataClassInfo dataClassInfo, Guid reusableFieldSchemaGuid)
     {
         var formInfo = new FormInfo(dataClassInfo.ClassFormDefinition);
-        var schema = reusableFieldSchemaManager.Get(reusableFieldSchemaGuid);
-        formInfo.AddFormItem(new FormSchemaInfo { Name = schema.Name, Guid = reusableFieldSchemaGuid });
+        formInfo.AddFormItem(new FormSchemaInfo { Name = reusableFieldSchemaGuid.ToString(), Guid = reusableFieldSchemaGuid });
         dataClassInfo.ClassFormDefinition = formInfo.GetXmlDefinition();
     }
 
@@ -94,7 +93,7 @@ public class ReusableSchemaService(ILogger<ReusableSchemaService> logger, ToolCo
         var schema = reusableFieldSchemaManager.Get(reusableFieldSchemaName);
         if (!formInfo.ItemsList.Any(x => x is FormSchemaInfo fsi && fsi.Guid == schema.Guid))
         {
-            formInfo.AddFormItem(new FormSchemaInfo { Name = reusableFieldSchemaName, Guid = schema.Guid });
+            formInfo.AddFormItem(new FormSchemaInfo { Name = schema.Guid.ToString(), Guid = schema.Guid });
             dataClassInfo.ClassFormDefinition = formInfo.GetXmlDefinition();
         }
         return schema.Guid;


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #634 

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

- Uncomment `services.AddReusableSchemaIntegrationSample();` in ServiceCollectionExtensions.cs
- Migrate KX13 DancingGoatCore
- After the migration, open the XbK database
- In the CMS_Class locate the DancingGoatCore.CafeRS content type
- Check the ClassFormDefinition xml, there should be 2 schemas, the name attributes should be guid values 
<img width="2374" height="335" alt="image" src="https://github.com/user-attachments/assets/ed9e59e2-54ac-4702-aa74-d579949497ab" />

