### PR TITLE
Remove unmaintained extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,8 +4,5 @@
     "esbenp.prettier-vscode",
     "davidanson.vscode-markdownlint",
     "editorconfig.editorconfig",
-    "adrianwilczynski.user-secrets",
-    "dotjoshjohnson.xml",
-    "tintoy.msbuild-project-tools"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
     "ms-dotnettools.csdevkit",
     "esbenp.prettier-vscode",
     "davidanson.vscode-markdownlint",
-    "editorconfig.editorconfig",
+    "editorconfig.editorconfig"
   ]
 }


### PR DESCRIPTION
### Motivation

- Remove unmaintained VS Code extension recommendations as supply-chain security precaution

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

n/a
