### PR TITLE
Add information about page attachments and migrating checked-in pages

### DIFF
--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -140,7 +140,7 @@ pages, you must manually adjust your website's implementation to match the new d
 See [Editing components in Xperience by Kentico](https://docs.xperience.io/x/wIfWCQ) to learn more about some of the
 most common components and selectors.
 
-If migrated content types contain fields with names used internally in Xperience by Kentico (*Asset* or *SystemFields*), rename those fields after migration. For naming rules, see [Field naming guidelines](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#field-naming-guidelines).
+If migrated content types contain fields with names used internally in Xperience by Kentico (_Asset_ or _SystemFields_), rename those fields after migration. For naming rules, see [Field naming guidelines](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#field-naming-guidelines).
 
 #### Reusable field schemas
 
@@ -172,6 +172,7 @@ Pages from older product versions can be migrated to either to [website channel 
 - Linked pages are currently not supported in Xperience by Kentico. By default, the migration creates standard page copies for any
   linked pages on the source instance. This behavior can be changed by implementing [custom handling of linked pages](../docs/customization/Content-Item-Directors.md#customize-linked-page-handling).
 - Page permissions (ACLs) are currently not migrated into Xperience by Kentico.
+- We do not recommend migrating [checked out pages](https://docs.kentico.com/13/configuring-xperience/configuring-the-environment-for-content-editors/configuring-and-using-page-versioning/content-locking#checking-pages-in-and-out). Before migrating the pages, check-in all the pages you want to transfer to Xperience by Kentico.
 - Migration of Page Builder content is only available for Kentico Xperience 13.
 
 Additionally, you can define [custom migrations](../Migration.Tool.Extensions/README.md) to change the default behavior, for example to migrate page content to widgets in Xperience by Kentico.
@@ -302,6 +303,8 @@ If required, you can [configure the tool](#convert-attachments-and-media-library
 #### Attachments
 
 Attachment files are migrated together with pages when using the `--pages` parameter. They are migrated as [content item assets](https://docs.kentico.com/x/content_item_assets_xp) to Content hub into a content folder `<site_name>/__Attachments`. Assets are created in the specified language if the language is available (e.g., attachments of pages). Migrated assets are created as content items of a _Legacy attachment_ content type (code name `Legacy.Attachment`) created by the tool.
+
+> :warning: **Warning** – Only attachments [stored in the database](https://docs.kentico.com/13/configuring-xperience/managing-files/storing-files) are currently migrated. To migrate attachments stored on the file system, enable storing files in the database and file system, and [copy the attachments](https://docs.kentico.com/13/configuring-xperience/managing-files/administering-files-globally#attachments-tab) to the database.
 
 If you want to use Xperience by Kentico's [automatic image optimization](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#configure-asset-content-types) feature for the _Legacy attachment_ type, follow along with our [guide about customizing asset migration](https://docs.kentico.com/x/optimize_images_during_upgrade_guides).
 

--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -172,7 +172,7 @@ Pages from older product versions can be migrated to either to [website channel 
 - Linked pages are currently not supported in Xperience by Kentico. By default, the migration creates standard page copies for any
   linked pages on the source instance. This behavior can be changed by implementing [custom handling of linked pages](../docs/customization/Content-Item-Directors.md#customize-linked-page-handling).
 - Page permissions (ACLs) are currently not migrated into Xperience by Kentico.
-- We do not recommend migrating [checked out pages](https://docs.kentico.com/13/configuring-xperience/configuring-the-environment-for-content-editors/configuring-and-using-page-versioning/content-locking#checking-pages-in-and-out). Before migrating the pages, check-in all the pages you want to transfer to Xperience by Kentico.
+- We DO NOT recommend migrating [checked out pages](https://docs.kentico.com/13/configuring-xperience/configuring-the-environment-for-content-editors/configuring-and-using-page-versioning/content-locking#checking-pages-in-and-out). Before migrating the pages, check in all the pages you want to transfer to Xperience by Kentico.
 - Migration of Page Builder content is only available for Kentico Xperience 13.
 
 Additionally, you can define [custom migrations](../Migration.Tool.Extensions/README.md) to change the default behavior, for example to migrate page content to widgets in Xperience by Kentico.
@@ -304,7 +304,7 @@ If required, you can [configure the tool](#convert-attachments-and-media-library
 
 Attachment files are migrated together with pages when using the `--pages` parameter. They are migrated as [content item assets](https://docs.kentico.com/x/content_item_assets_xp) to Content hub into a content folder `<site_name>/__Attachments`. Assets are created in the specified language if the language is available (e.g., attachments of pages). Migrated assets are created as content items of a _Legacy attachment_ content type (code name `Legacy.Attachment`) created by the tool.
 
-> :warning: **Warning** – Only attachments [stored in the database](https://docs.kentico.com/13/configuring-xperience/managing-files/storing-files) are currently migrated. To migrate attachments stored on the file system, enable storing files in the database and file system, and [copy the attachments](https://docs.kentico.com/13/configuring-xperience/managing-files/administering-files-globally#attachments-tab) to the database.
+> :warning: **Warning** – Only attachments [stored in the database](https://docs.kentico.com/13/configuring-xperience/managing-files/storing-files) are currently migrated. To migrate attachments stored on the file system, enable storing files in the _database and file system_, and [copy the attachments](https://docs.kentico.com/13/configuring-xperience/managing-files/administering-files-globally#attachments-tab) to the database.
 
 If you want to use Xperience by Kentico's [automatic image optimization](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#configure-asset-content-types) feature for the _Legacy attachment_ type, follow along with our [guide about customizing asset migration](https://docs.kentico.com/x/optimize_images_during_upgrade_guides).
 


### PR DESCRIPTION
… in KX13

### Motivation

Provide additional information about migrating page attachments and KX13 pages with content locking enabled.

### Checklist

- [x] Code follows coding conventions held in this repo -- N/A – docs-only change
- [~] Automated tests have been added  -- N/A – docs-only change
- [~] Tests are passing -- N/A – docs-only change
- [x] Docs have been updated
- [~] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults -- N/A – docs-only change

### How to test

Review the added content for accuracy against KX13 behavior for page attachments and content locking.
