### PR TITLE
Content folders - implementation of characters truncation in names

### DIFF
--- a/Migration.Tool.Common/Helpers/UniqueNameHelper.cs
+++ b/Migration.Tool.Common/Helpers/UniqueNameHelper.cs
@@ -6,8 +6,18 @@ public static class UniqueNameHelper
     /// <paramref name="availabilityChecker"/>, which determines, whether the candidate can be used.
     /// If <paramref name="maxLength"/> is specified, returned value is guaranteed not to exceed that length.
     /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="maxLength"/> is smaller than <see cref="SuffixLength"/> + 2, which is the
+    /// minimum length required to keep at least one character of <paramref name="name"/> and append a unique
+    /// suffix without exceeding <paramref name="maxLength"/>.
+    /// </exception>
     public static string MakeUnique(string name, Func<string, bool> availabilityChecker, int? maxLength = null)
     {
+        if (maxLength.HasValue && maxLength.Value < (SuffixLength + 2))
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength.Value, $"{nameof(maxLength)} must be at least {SuffixLength + 2} to keep at least one character of the original name and append a unique suffix.");
+        }
+
         string baseName = maxLength.HasValue
             ? TruncateToLength(name, maxLength.Value)
             : name;

--- a/Migration.Tool.Common/Helpers/UniqueNameHelper.cs
+++ b/Migration.Tool.Common/Helpers/UniqueNameHelper.cs
@@ -3,15 +3,23 @@ public static class UniqueNameHelper
 {
     /// <summary>
     /// Makes name unique by trying to append pseudorandom suffixes. Candidates are offered to 
-    /// <paramref name="availabilityChecker"/>, which determines, whether the candidate can be used
+    /// <paramref name="availabilityChecker"/>, which determines, whether the candidate can be used.
+    /// If <paramref name="maxLength"/> is specified, returned value is guaranteed not to exceed that length.
     /// </summary>
-    public static string MakeUnique(string name, Func<string, bool> availabilityChecker)
+    public static string MakeUnique(string name, Func<string, bool> availabilityChecker, int? maxLength = null)
     {
-        string uniqueCodeName = name;
+        string baseName = maxLength.HasValue
+            ? TruncateToLength(name, maxLength.Value)
+            : name;
+
+        string uniqueCodeName = baseName;
         int attemptIndex = 0;
         while (attemptIndex < UniqueSuffixCount && !availabilityChecker(uniqueCodeName)) // While conflict, try new GUID suffix to make unique
         {
-            uniqueCodeName = $"{name}-{GetSuffix(attemptIndex++)}";
+            var suffix = GetSuffix(attemptIndex++);
+            uniqueCodeName = maxLength.HasValue
+                ? $"{TruncateToLength(baseName, Math.Max(0, maxLength.Value - SuffixLength - 1))}-{suffix}"
+                : $"{baseName}-{suffix}";
         }
         if (attemptIndex >= UniqueSuffixCount)
         {
@@ -19,6 +27,8 @@ public static class UniqueNameHelper
         }
         return uniqueCodeName;
     }
+
+    private static string TruncateToLength(string value, int maxLength) => value.Length <= maxLength ? value : value[..maxLength];
 
     /// <summary>
     /// Returns pseudorandom string of <see cref="SuffixLength"/> characters. 

--- a/Migration.Tool.Common/Services/ContentFolderService.cs
+++ b/Migration.Tool.Common/Services/ContentFolderService.cs
@@ -1,4 +1,4 @@
-﻿using CMS.ContentEngine;
+using CMS.ContentEngine;
 using CMS.Helpers;
 using Kentico.Xperience.UMT.Model;
 using Kentico.Xperience.UMT.Services;
@@ -41,7 +41,7 @@ public class ContentFolderService(IImporter importer, ILogger<ContentFolderServi
             else
             {
                 var folderInfo = ContentFolderInfo.Provider.Get()
-                    .And().WhereEquals(nameof(ContentFolderInfo.ContentFolderTreePath), folderTemplate.DisplayName)
+                    .And().WhereEquals(nameof(ContentFolderInfo.ContentFolderTreePath), currentPath)
                     .And().WhereEquals(nameof(ContentFolderInfo.ContentFolderWorkspaceID), workspaceInfo.WorkspaceID)
                     .FirstOrDefault();
 
@@ -50,8 +50,8 @@ public class ContentFolderService(IImporter importer, ILogger<ContentFolderServi
                     var newFolderModel = new ContentFolderModel
                     {
                         ContentFolderGUID = folderTemplate.Guid,
-                        ContentFolderName = UniqueNameHelper.MakeUnique(folderTemplate.Name, x => !ContentFolderInfo.Provider.Get().WhereEquals(nameof(ContentFolderInfo.ContentFolderName), x).Any()),
-                        ContentFolderDisplayName = folderTemplate.DisplayName,
+                        ContentFolderName = UniqueNameHelper.MakeUnique(folderTemplate.Name, x => !ContentFolderInfo.Provider.Get().WhereEquals(nameof(ContentFolderInfo.ContentFolderName), x).Any(), 50),
+                        ContentFolderDisplayName = folderTemplate.DisplayName.Truncate(50),
                         ContentFolderTreePath = currentPath,
                         ContentFolderParentFolderGUID = parentFolderInfo.ContentFolderGUID,
                         ContentFolderWorkspaceGUID = workspaceInfo.WorkspaceGUID

--- a/Migration.Tool.Common/Services/ContentFolderService.cs
+++ b/Migration.Tool.Common/Services/ContentFolderService.cs
@@ -9,6 +9,9 @@ using Migration.Tool.Common.Helpers;
 namespace Migration.Tool.Common.Services;
 public class ContentFolderService(IImporter importer, ILogger<ContentFolderService> logger, WorkspaceService workspaceService)
 {
+    private const int MaxFolderNameLength = 50;
+    private const int MaxFolderDisplayNameLength = 50;
+
     /// <summary>
     /// Folder tree path as key
     /// </summary>
@@ -50,8 +53,8 @@ public class ContentFolderService(IImporter importer, ILogger<ContentFolderServi
                     var newFolderModel = new ContentFolderModel
                     {
                         ContentFolderGUID = folderTemplate.Guid,
-                        ContentFolderName = UniqueNameHelper.MakeUnique(folderTemplate.Name, x => !ContentFolderInfo.Provider.Get().WhereEquals(nameof(ContentFolderInfo.ContentFolderName), x).Any(), 50),
-                        ContentFolderDisplayName = folderTemplate.DisplayName.Truncate(50),
+                        ContentFolderName = UniqueNameHelper.MakeUnique(folderTemplate.Name, x => !ContentFolderInfo.Provider.Get().WhereEquals(nameof(ContentFolderInfo.ContentFolderName), x).Any(), MaxFolderNameLength),
+                        ContentFolderDisplayName = folderTemplate.DisplayName.Truncate(MaxFolderDisplayNameLength),
                         ContentFolderTreePath = currentPath,
                         ContentFolderParentFolderGUID = parentFolderInfo.ContentFolderGUID,
                         ContentFolderWorkspaceGUID = workspaceInfo.WorkspaceGUID


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`631`

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

In KX13 Admin UI, media library folder names are limited to 50 characters, but you can create longer names manually on the filesystem.

<img width="2736" height="936" alt="image" src="https://github.com/user-attachments/assets/f59128b7-38bd-4ddd-bd5f-464ac126e82f" /> 
<img width="2112" height="741" alt="image" src="https://github.com/user-attachments/assets/82a2e199-cc18-4eeb-8b38-f3f23bc7cebb" />



- On the filesystem, go to the CMS\DancingGoatCore\media folder
- Choose some Media library/subfolder
- Create a new subfolder with a name longer than 50 characters 
<img width="1625" height="696" alt="image" src="https://github.com/user-attachments/assets/22b3282e-7574-4f0d-9540-aad1cc9e4392" />

- Switch to the admin UI and upload a media file to this new folder
- Configure the KMT config file, **MigrateMediaToMediaLibrary** should be set to **false**
- Start complete migration with parameters `migrate --sites --custom-modules --users --settings-keys --page-types --pages --type-restrictions --contact-management --forms --media-libraries --data-protection --custom-tables --members --categories`
- Check that the new folder is correctly created as a content hub content folder and the media file is migrated 
<img width="1771" height="1679" alt="image" src="https://github.com/user-attachments/assets/f3c18709-8032-48c6-a702-1b67240eff20" />
