### PR TITLE
Always set 'LegacyMediaFileAsset' column when migrating files as Lega…

### DIFF
--- a/KVA/Migration.Tool.Source/Services/AssetFacade.cs
+++ b/KVA/Migration.Tool.Source/Services/AssetFacade.cs
@@ -133,10 +133,7 @@ public class AssetFacade(
             {
                 [LegacyMediaFileTitleField.Column!] = mediaFile.FileTitle,
                 [LegacyMediaFileDescriptionField.Column!] = mediaFile.FileDescription,
-            };
-            if (!toolConfiguration.MigrateOnlyMediaFileInfo.GetValueOrDefault(false))
-            {
-                contentItemData[LegacyMediaFileAssetField.Column!] = new AssetFileSource
+                [LegacyMediaFileAssetField.Column!] = new AssetFileSource
                 {
                     ContentItemGuid = translatedMediaGuid,
                     Identifier = GuidHelper.CreateAssetGuid(translatedMediaGuid, contentLanguageName),
@@ -146,8 +143,8 @@ public class AssetFacade(
                     Size = null,
                     LastModified = null,
                     FilePath = mediaFilePath
-                };
-            }
+                },
+            };
 
             return new ContentItemLanguageData
             {


### PR DESCRIPTION

### Motivation

Fixes #644 

When `MigrateOnlyMediaFileInfo` is enabled, media library files migrated to Content hub as `Legacy.MediaFile` items were missing the `LegacyMediaFileAsset` field value. This meant the media item existed, but had no deterministic asset metadata/identifier, so manually transferring binaries to blob storage later could not restore the asset association.

<img width="919" height="293" alt="image" src="https://github.com/user-attachments/assets/75fdba80-30ea-41f1-ba37-74146b17610d" />


This change keeps binary transfer disabled in info-only mode, but still writes the asset metadata JSON required by Xperience to associate the content item with a future asset file.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (not applicable; existing documented behavior is preserved)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

1. Configure media migration to Content hub with info-only media import:
2. Store media files in filesystem of source K13 CMS site e.g. `~/CMS/media/<sitename>/<library folders>`
3. Run a complete import
4. Query the `Legacy_MediaFile` table after migration has completed and confirm that the asset metadata is set

<img width="1041" height="283" alt="image" src="https://github.com/user-attachments/assets/f5024287-4f22-4d93-93ca-6a3e8645c2d8" />
