### PR TITLE
Reusable schemas - added WithFieldPatch support plus GUID collision detection

### DIFF
--- a/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
+++ b/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
@@ -240,6 +240,8 @@ public class ClassMappingProvider(
 
     private void ExecReusableSchemaBuilders()
     {
+        var resolvedSchemas = new List<(IReusableSchemaBuilder Schema, FormFieldInfo[] Fields, SourceFieldIdentifier? SourceFieldIdentifier)>();
+
         foreach (var reusableSchemaBuilder in reusableSchemaBuilders)
         {
             reusableSchemaBuilder.AssertIsValid();
@@ -280,7 +282,7 @@ public class ClassMappingProvider(
                     {
                         case { Factory: { } factory }:
                         {
-                            return factory();
+                            return (Field: factory(), fb.SourceFieldIdentifier);
                         }
                         case { SourceFieldIdentifier: { } fieldIdentifier }:
                         {
@@ -318,7 +320,13 @@ public class ClassMappingProvider(
                                     $"Invalid reusable schema field builder for field '{fieldIdentifier.ClassName}': Class '{fieldIdentifier.ClassName}' is missing field '{fieldIdentifier.FieldName}'")
                             };
                             patchedFieldInfo.Name = fb.TargetFieldName;
-                            return patchedFieldInfo;
+
+                            if (fb.TargetFieldPatchers.ContainsKey(fb.TargetFieldName))
+                            {
+                                fb.TargetFieldPatchers[fb.TargetFieldName](patchedFieldInfo);
+                            }
+
+                            return (Field: patchedFieldInfo, fb.SourceFieldIdentifier);
                         }
                         default:
                         {
@@ -326,11 +334,51 @@ public class ClassMappingProvider(
                                 $"Invalid reusable schema field builder for field '{fb.TargetFieldName}'");
                         }
                     }
-                });
+                }).ToArray();
+
+                foreach (var fieldInfo in fieldInfos)
+                {
+                    resolvedSchemas.Add((reusableSchemaBuilder, [fieldInfo.Field], fieldInfo.SourceFieldIdentifier));
+                }
 
                 reusableSchemaService.EnsureReusableFieldSchema(reusableSchemaBuilder.SchemaName,
                     reusableSchemaBuilder.SchemaDisplayName, reusableSchemaBuilder.SchemaDescription,
-                    fieldInfos.ToArray());
+                    fieldInfos.Select(x => x.Field).ToArray());
+            }
+        }
+
+        AssertReusableSchemasHaveNoDuplicateFieldGuids(resolvedSchemas);
+    }
+
+    private void AssertReusableSchemasHaveNoDuplicateFieldGuids(List<(IReusableSchemaBuilder Schema, FormFieldInfo[] Fields, SourceFieldIdentifier? SourceFieldIdentifier)> resolvedSchemas)
+    {
+        var fieldsFromSource = resolvedSchemas
+            .Where(x => x.SourceFieldIdentifier is not null)
+            .SelectMany(x => x.Fields.Select(f => new
+            {
+                x.Schema.SchemaName,
+                SourceField = x.SourceFieldIdentifier!,
+                FieldGuid = f.Guid
+            }))
+            .ToList();
+
+        var duplicateGroups = fieldsFromSource
+            .GroupBy(f => (f.SourceField.ClassName.ToLowerInvariant(), f.SourceField.FieldName.ToLowerInvariant()))
+            .Where(g => g.Count() > 1);
+
+        foreach (var group in duplicateGroups)
+        {
+            var guidCollisions = group
+                .GroupBy(f => f.FieldGuid)
+                .Where(g => g.Count() > 1);
+
+            foreach (var collision in guidCollisions)
+            {
+                string schemaNames = string.Join(", ", collision.Select(s => $"'{s.SchemaName}'"));
+                throw new InvalidOperationException(
+                    $"Reusable schemas {schemaNames} share the same source field '{group.First().SourceField.ClassName}.{group.First().SourceField.FieldName}' " +
+                    $"and the resulting field GUID '{collision.Key}' is identical. This will cause a GUID collision. " +
+                    $"Use 'WithFieldPatch' to change the GUID (e.g., ffi.Guid = new Guid(...)) on at least one of the fields.");
             }
         }
     }

--- a/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
+++ b/KVA/Migration.Tool.Source/Providers/ClassMappingProvider.cs
@@ -347,40 +347,40 @@ public class ClassMappingProvider(
             }
         }
 
-        AssertReusableSchemasHaveNoDuplicateFieldGuids(resolvedSchemas);
-    }
-
-    private void AssertReusableSchemasHaveNoDuplicateFieldGuids(List<(IReusableSchemaBuilder Schema, FormFieldInfo[] Fields, SourceFieldIdentifier? SourceFieldIdentifier)> resolvedSchemas)
-    {
-        var fieldsFromSource = resolvedSchemas
-            .Where(x => x.SourceFieldIdentifier is not null)
-            .SelectMany(x => x.Fields.Select(f => new
-            {
-                x.Schema.SchemaName,
-                SourceField = x.SourceFieldIdentifier!,
-                FieldGuid = f.Guid
-            }))
-            .ToList();
-
-        var duplicateGroups = fieldsFromSource
-            .GroupBy(f => (f.SourceField.ClassName.ToLowerInvariant(), f.SourceField.FieldName.ToLowerInvariant()))
-            .Where(g => g.Count() > 1);
-
-        foreach (var group in duplicateGroups)
+        void AssertReusableSchemasHaveNoDuplicateFieldGuids()
         {
-            var guidCollisions = group
-                .GroupBy(f => f.FieldGuid)
+            var fieldsFromSource = resolvedSchemas
+                .Where(x => x.SourceFieldIdentifier is not null)
+                .SelectMany(x => x.Fields.Select(f => new
+                {
+                    x.Schema.SchemaName,
+                    SourceField = x.SourceFieldIdentifier!,
+                    FieldGuid = f.Guid
+                }))
+                .ToList();
+
+            var duplicateGroups = fieldsFromSource
+                .GroupBy(f => (f.SourceField.ClassName.ToLowerInvariant(), f.SourceField.FieldName.ToLowerInvariant()))
                 .Where(g => g.Count() > 1);
 
-            foreach (var collision in guidCollisions)
+            foreach (var group in duplicateGroups)
             {
-                string schemaNames = string.Join(", ", collision.Select(s => $"'{s.SchemaName}'"));
-                throw new InvalidOperationException(
-                    $"Reusable schemas {schemaNames} share the same source field '{group.First().SourceField.ClassName}.{group.First().SourceField.FieldName}' " +
-                    $"and the resulting field GUID '{collision.Key}' is identical. This will cause a GUID collision. " +
-                    $"Use 'WithFieldPatch' to change the GUID (e.g., ffi.Guid = new Guid(...)) on at least one of the fields.");
+                var guidCollisions = group
+                    .GroupBy(f => f.FieldGuid)
+                    .Where(g => g.Count() > 1);
+
+                foreach (var collision in guidCollisions)
+                {
+                    string schemaNames = string.Join(", ", collision.Select(s => $"'{s.SchemaName}'"));
+                    throw new InvalidOperationException(
+                        $"Reusable schemas {schemaNames} share the same source field '{group.First().SourceField.ClassName}.{group.First().SourceField.FieldName}' " +
+                        $"and the resulting field GUID '{collision.Key}' is identical. This will cause a GUID collision. " +
+                        $"Use 'WithFieldPatch' to change the GUID (e.g., ffi.Guid = new Guid(...)) on at least one of the fields.");
+                }
             }
         }
+
+        AssertReusableSchemasHaveNoDuplicateFieldGuids();
     }
 
     private void EnsureSettings()

--- a/Migration.Tool.Common/Builders/ReusableSchemaBuilder.cs
+++ b/Migration.Tool.Common/Builders/ReusableSchemaBuilder.cs
@@ -124,9 +124,11 @@ public class ReusableFieldBuilder(string targetFieldName) : IReusableFieldBuilde
 
     public IReusableFieldBuilder WithFieldPatch(Action<FormFieldInfo> fieldInfoPatcher)
     {
+        ArgumentNullException.ThrowIfNull(fieldInfoPatcher);
+
         if (!TargetFieldPatchers.TryAdd(TargetFieldName, fieldInfoPatcher))
         {
-            throw new InvalidOperationException($"Target field mapper can be defined only once for each field, field '{targetFieldName}' has one already defined");
+            throw new InvalidOperationException($"Target field patcher can be defined only once for each field, field '{TargetFieldName}' has one already defined");
         }
         return this;
     }

--- a/Migration.Tool.Common/Builders/ReusableSchemaBuilder.cs
+++ b/Migration.Tool.Common/Builders/ReusableSchemaBuilder.cs
@@ -78,10 +78,12 @@ public interface IReusableFieldBuilder
     string TargetFieldName { get; }
     Func<FormFieldInfo>? Factory { get; }
     SourceFieldIdentifier? SourceFieldIdentifier { get; }
+    IDictionary<string, Action<FormFieldInfo>> TargetFieldPatchers { get; }
 
     void AssertIsValid();
     IReusableFieldBuilder WithFactory(Func<FormFieldInfo> formFieldFactory);
     IReusableFieldBuilder CreateFrom(string sourceClassName, string sourceFieldName);
+    IReusableFieldBuilder WithFieldPatch(Action<FormFieldInfo> fieldInfoPatcher);
 }
 
 public class ReusableFieldBuilder(string targetFieldName) : IReusableFieldBuilder
@@ -89,6 +91,7 @@ public class ReusableFieldBuilder(string targetFieldName) : IReusableFieldBuilde
     public string TargetFieldName { get; } = targetFieldName;
     public Func<FormFieldInfo>? Factory { get; private set; }
     public SourceFieldIdentifier? SourceFieldIdentifier { get; private set; }
+    public IDictionary<string, Action<FormFieldInfo>> TargetFieldPatchers { get; } = new Dictionary<string, Action<FormFieldInfo>>();
 
     public void AssertIsValid()
     {
@@ -116,6 +119,15 @@ public class ReusableFieldBuilder(string targetFieldName) : IReusableFieldBuilde
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceFieldName, nameof(sourceFieldName));
 
         SourceFieldIdentifier = new SourceFieldIdentifier(sourceClassName, sourceFieldName);
+        return this;
+    }
+
+    public IReusableFieldBuilder WithFieldPatch(Action<FormFieldInfo> fieldInfoPatcher)
+    {
+        if (!TargetFieldPatchers.TryAdd(TargetFieldName, fieldInfoPatcher))
+        {
+            throw new InvalidOperationException($"Target field mapper can be defined only once for each field, field '{targetFieldName}' has one already defined");
+        }
         return this;
     }
 }

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -525,7 +525,7 @@ public static class ClassMappingSample
 
 
         // Sample: multiple reusable schemas sharing the same source field.
-        // When two schemas map a field from the same source, use WithFieldPatch to change the target GUID to avoid GUID collision.
+        // When two schemas map a field from the same source, use WithFieldPatch on at least one of the fields to change the target GUID to avoid GUID collision.
         var sb3 = new ReusableSchemaBuilder(schemaNameDgcContact, "Contact information", "Reusable schema that defines contact information");
         sb3
             .BuildField("ContactPhone")

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -460,6 +460,7 @@ public static class ClassMappingSample
     public static IServiceCollection AddReusableSchemaIntegrationSample(this IServiceCollection serviceCollection)
     {
         const string schemaNameDgcCommon = "DGC.Address";
+        const string schemaNameDgcContact = "DGC.Contact";
         const string schemaNameDgcName = "DGC.Name";
         const string sourceClassName = "DancingGoatCore.Cafe";
 
@@ -522,6 +523,17 @@ public static class ClassMappingSample
                 }
             });
 
+
+        var sb3 = new ReusableSchemaBuilder(schemaNameDgcContact, "Contact information", "Reusable schema that defines contact information");
+        sb3
+            .BuildField("ContactPhone")
+            .CreateFrom(sourceClassName, "CafePhone")
+            .WithFieldPatch(f =>
+            {
+                f.Caption = "Contact Phone";
+                f.Guid = new Guid("C9D7B0A1-3F4E-4D2A-BB5F-8C6D7E5F9A1B");
+            });
+
         var m = new MultiClassMapping("DancingGoatCore.CafeRS", target =>
         {
             target.ClassName = "DancingGoatCore.CafeRS";
@@ -536,10 +548,12 @@ public static class ClassMappingSample
 
         // declare that we intend to use reusable schema and set mappings to new fields from old ones
         m.UseReusableSchema(schemaNameDgcCommon);
+        m.UseReusableSchema(schemaNameDgcContact);
         m.BuildField("City").SetFrom(sourceClassName, "CafeCity");
         m.BuildField("Street").SetFrom(sourceClassName, "CafeStreet");
         m.BuildField("ZipCode").SetFrom(sourceClassName, "CafeZipCode");
         m.BuildField("Phone").SetFrom(sourceClassName, "CafePhone");
+        m.BuildField("ContactPhone").SetFrom(sourceClassName, "CafePhone");
 
         m.UseReusableSchema(schemaNameDgcName);
         m.BuildField("Name").SetFrom(sourceClassName, "CafeName");
@@ -560,6 +574,7 @@ public static class ClassMappingSample
         // register reusable schema builder
         serviceCollection.AddSingleton<IReusableSchemaBuilder>(sb);
         serviceCollection.AddSingleton<IReusableSchemaBuilder>(sb2);
+        serviceCollection.AddSingleton<IReusableSchemaBuilder>(sb3);
 
         return serviceCollection;
     }

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -524,6 +524,8 @@ public static class ClassMappingSample
             });
 
 
+        // Sample: multiple reusable schemas sharing the same source field.
+        // When two schemas map a field from the same source, use WithFieldPatch to change the target GUID to avoid GUID collision.
         var sb3 = new ReusableSchemaBuilder(schemaNameDgcContact, "Contact information", "Reusable schema that defines contact information");
         sb3
             .BuildField("ContactPhone")

--- a/docs/customization/Class-Mappings.md
+++ b/docs/customization/Class-Mappings.md
@@ -102,6 +102,28 @@ Mappings replace the default migration behavior for any source class with at lea
 
 Usage of `ReusableSchemaBuilder` in custom class mappings cannot be combined with the `Settings.CreateReusableFieldSchemaForClasses` configuration option.
 
+### Shared Source Fields Across Multiple Schemas
+
+When two or more reusable schemas define fields that originate from the same source field (using `CreateFrom`), the resulting target fields will have identical GUIDs by default. This causes a GUID collision in Xperience by Kentico.
+
+To avoid this, use `WithFieldPatch` on at least one of the fields to assign a new GUID:
+
+```csharp
+var schema1 = new ReusableSchemaBuilder("DGC.Address", "Address", "Address schema");
+schema1.BuildField("Phone").CreateFrom("DancingGoatCore.Cafe", "CafePhone");
+
+var schema2 = new ReusableSchemaBuilder("DGC.Contact", "Contact", "Contact schema");
+schema2.BuildField("ContactPhone")
+    .CreateFrom("DancingGoatCore.Cafe", "CafePhone")
+    .WithFieldPatch(f =>
+    {
+        f.Guid = Guid.NewGuid(); // Required to avoid GUID collision
+    });
+```
+
+> [!NOTE]
+> The migration tool validates this scenario at runtime. If two schemas share the same source field and the resulting GUIDs are identical, an exception is thrown with guidance to apply `WithFieldPatch`.
+
 ### Remodel Page Types as Reusable Field Schemas Guide
 
 For an end-to-end example of how to extract common fields from two page types from Kentico Xperience 13 and move them to a [reusable field schema](https://docs.kentico.com/x/D4_OD) shared by both web page content types in Xperience by Kentico, follow this [migration guide](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides).


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`648`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Happy path
- In the ServiceCollectionExtensions uncomment the services.AddReusableSchemaIntegrationSample() line
- Run DancingGoatCore migration (complete migration with all types)
- Check the CafeRS content type, there should be 3 reusable schemas
- Open some page of the CafeRS content type
- Check that Phone/Contact Phone fields are not empty and values are equal 
<img width="3129" height="1686" alt="image" src="https://github.com/user-attachments/assets/0c588cac-fa5d-47e3-8c17-d8e222452248" />

GUID collision path
- Use fresh target DB
- Go to ClassMappingSample.AddReusableSchemaIntegrationSample method
- Locate the following code `var sb3 = new ReusableSchemaBuilder(schemaNameDgcContact, "Contact information", "Reusable schema that defines contact information");
        sb3
            .BuildField("ContactPhone")
            .CreateFrom(sourceClassName, "CafePhone")
            .WithFieldPatch(f =>
            {
                f.Caption = "Contact  #Phone";
                f.Guid = new Guid("C9D7B0A1-3F4E-4D2A-BB5F-8C6D7E5F9A1B");
            });`
- remove the line `f.Guid = new Guid("C9D7B0A1-3F4E-4D2A-BB5F-8C6D7E5F9A1B");`
- Run migration
- Check that the migration failed; there should be an error message about guid collision `                throw new InvalidOperationException(
                    $"Reusable schemas {schemaNames} share the same source field '{group.First().SourceField.ClassName}.{group.First().SourceField.FieldName}' " +
                    $"and the resulting field GUID '{collision.Key}' is identical. This will cause a GUID collision. " +
                    $"Use 'WithFieldPatch' to change the GUID (e.g., ffi.Guid = new Guid(...)) on at least one of the fields.");`

  
