### PR TITLE
Fix: document required settings for custom-mapped fields

### DIFF
--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -134,13 +134,12 @@ Additionally, you can enable the Conversion of text fields with media links (_Me
 library files by setting
 the `OptInFeatures.CustomMigration.FieldMigrations` [configuration option](#convert-text-fields-with-media-links). If you need additional control or want to customize the default mappings of data types, you can [customize the Migration Tool behavior](../Migration.Tool.Extensions/README.md).
 
-Some [Form components](https://docs.xperience.io/x/5ASiCQ) used by content type fields in Xperience by Kentico store
-data differently than their equivalent Form control in Xperience 13. To ensure that content is displayed correctly on
-pages, you must manually adjust your website's implementation to match the new data format.
-See [Editing components in Xperience by Kentico](https://docs.xperience.io/x/wIfWCQ) to learn more about some of the
-most common components and selectors.
+Some [Form components](https://docs.xperience.io/x/5ASiCQ) used by content type fields in Xperience by Kentico store data differently than their equivalent Form control in Xperience 13. To ensure that content is displayed correctly on pages, you must manually adjust your website's implementation to match the new data format.
+See [Editing components in Xperience by Kentico](https://docs.xperience.io/x/wIfWCQ) to learn more about some of the most common components and selectors.
 
-If migrated content types contain fields with names used internally in Xperience by Kentico (*Asset* or *SystemFields*), rename those fields after migration. For naming rules, see [Field naming guidelines](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#field-naming-guidelines).
+Unsupported data types, such as GUID or Time interval, do not have matching form components in Xperience by Kentico. As a result, the tool automatically hides these fields in the UI to prevent validation errors. To migrate these fields, use [custom class mapping](../Migration.Tool.Extensions/README.md) with `WithFieldPatch` set to `field.Visible = true`, and specify the appropriate form component and its settings. `WithFieldPatch` applies these overrides after the default field configuration.
+
+If migrated content types contain fields with names used internally in Xperience by Kentico (_Asset_ or _SystemFields_), rename those fields after migration. For naming rules, see [Field naming guidelines](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#field-naming-guidelines).
 
 #### Reusable field schemas
 

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -148,6 +148,9 @@ public static class ClassMappingSample
             target.ClassDisplayName = "Coffee remodeled";
             target.ClassType = ClassType.CONTENT_TYPE;
             target.ClassContentTypeType = ClassContentTypeType.WEBSITE;
+            // For page (WEBSITE) content types, set to true to preserve URLs and routing ("Include in routing")
+            // Custom mappings do not inherit this automatically; if omitted, it defaults to false and routing is disabled
+            target.ClassWebPageHasUrl = true;
         });
 
         // set new primary key
@@ -205,6 +208,9 @@ public static class ClassMappingSample
             target.ClassDisplayName = "ET - MY new transformed event";
             target.ClassType = ClassType.CONTENT_TYPE;
             target.ClassContentTypeType = ClassContentTypeType.WEBSITE;
+            // For page (WEBSITE) content types, set to `true` to preserve URLs and routing ("Include in routing")
+            // Custom mappings do not inherit this automatically; if omitted, it defaults to false and routing is disabled
+            target.ClassWebPageHasUrl = true;
         });
 
         // register custom table handler once for all custom table mappings
@@ -218,7 +224,7 @@ public static class ClassMappingSample
         title.SetFrom(sourceClassName1, "EventTitle", true);
         // map "EventTitle" field form source data class "_ET.Event2"
         title.SetFrom(sourceClassName2, "EventTitle");
-        // patch field definition, in this case lets change field caption 
+        // patch field definition, in this case lets change field caption
         title.WithFieldPatch(f => f.Caption = "Event title");
 
 
@@ -529,6 +535,7 @@ public static class ClassMappingSample
             target.ClassDisplayName = "Coffee with reusable schema";
             target.ClassType = ClassType.CONTENT_TYPE;
             target.ClassContentTypeType = ClassContentTypeType.WEBSITE;
+            target.ClassWebPageHasUrl = true;
         });
 
         // set primary key
@@ -585,6 +592,7 @@ public static class ClassMappingSample
             target.ClassDisplayName = "Article with reusable schema";
             target.ClassType = ClassType.CONTENT_TYPE;
             target.ClassContentTypeType = ClassContentTypeType.WEBSITE;
+            target.ClassWebPageHasUrl = true;
         });
 
         // set primary key

--- a/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
+++ b/Migration.Tool.Extensions/ClassMappings/ClassMappingSample.cs
@@ -224,7 +224,7 @@ public static class ClassMappingSample
         title.SetFrom(sourceClassName1, "EventTitle", true);
         // map "EventTitle" field form source data class "_ET.Event2"
         title.SetFrom(sourceClassName2, "EventTitle");
-        // patch field definition, in this case lets change field caption
+        // patch field definition, in this case let's change field caption
         title.WithFieldPatch(f => f.Caption = "Event title");
 
 

--- a/docs/customization/Class-Mappings.md
+++ b/docs/customization/Class-Mappings.md
@@ -34,8 +34,8 @@ You can create multiple class mappings, each handling different source content t
    target.ClassType = ClassType.CONTENT_TYPE;
    // What the content type is used for (reusable content, pages, email, or headless)
    target.ClassContentTypeType = ClassContentTypeType.WEBSITE;
-   // For page content types, set to true to preserve URLs and routing (custom mappings do not inherit this automatically)
-   // When omitted, defaults to false and routing is disabled; leave at the default for reusable content
+   // For page content types, set to `true` to preserve URLs and routing (custom mappings do not inherit this automatically)
+   // When omitted, defaults to `false` and routing is disabled; leave at the default for reusable content
    target.ClassWebPageHasUrl = true;
    });
    ```

--- a/docs/customization/Class-Mappings.md
+++ b/docs/customization/Class-Mappings.md
@@ -8,7 +8,7 @@ You can create multiple class mappings, each handling different source content t
 
 **Use cases:**
 
-- Merge multiple page types (e.g., `Article.BlogPost`, `Article.NewsArticle`) into a single content type in the [content hub](https://docs.kentico.com/x/barWCQ)
+- Merge multiple page types (e.g., `Article.BlogPost`, `Article.NewsArticle`) into a single content type in the [Content hub](https://docs.kentico.com/x/barWCQ)
 - Remodel page types as [reusable field schemas](https://docs.kentico.com/x/remodel_page_types_as_reusable_field_schemas_guides) by extracting common fields
 - Change field names, data types, or form controls (e.g., rename `OldName` to `NewName` and convert from `text` to `longtext` or custom type)
 - Add new fields
@@ -34,8 +34,18 @@ You can create multiple class mappings, each handling different source content t
    target.ClassType = ClassType.CONTENT_TYPE;
    // What the content type is used for (reusable content, pages, email, or headless)
    target.ClassContentTypeType = ClassContentTypeType.WEBSITE;
+   // For page content types, set to true to preserve URLs and routing (custom mappings do not inherit this automatically)
+   // When omitted, defaults to false and routing is disabled; leave at the default for reusable content
+   target.ClassWebPageHasUrl = true;
    });
    ```
+
+   > [!WARNING]
+   > When your target content type is used for pages (`ClassContentTypeType.WEBSITE`), you must explicitly set `target.ClassWebPageHasUrl = true` to preserve the content type's URLs and routing (the "Include in routing" option in the administration).
+   >
+   > The default migration (without a custom class mapping) sets this automatically based on the source page type. Custom class mappings build the target content type from scratch and do not inherit this behavior, so when the property is omitted it defaults to `false` and routing is disabled. Once the content type is created without routing, the setting cannot be enabled afterward - you need to correct the mapping and run the migration again.
+   >
+   > For reusable content (for example, items migrated into the [Content hub](https://docs.kentico.com/x/barWCQ)), this property does not apply - leave it at its default of `false`.
 
 1. Define a new primary key:
 


### PR DESCRIPTION
### Motivation

Custom class mappings build the target content type from scratch and don't inherit behavior the default migration applies automatically. Documents two such cases and fixes the affected sample mappings:

- **Page routing** — `ClassWebPageHasUrl` defaults to `false` when omitted, so remodeled pages lose their URLs and "Include in routing" (can't be re-enabled after). Added a warning + set the flag in the WEBSITE samples. Fixes #620.
- **Field visibility** — fields not handled by default migration (e.g. GUID  data type) need visibility explicitly set to `true` in a custom migration, or they're invisible after migration. Added a note.

Docs and sample mappings only.