### PR TITLE
Add guidance for making legacy media file required during asset migra…

### DIFF
--- a/Migration.Tool.CLI/README.md
+++ b/Migration.Tool.CLI/README.md
@@ -289,7 +289,7 @@ Custom table migration does NOT include:
 
 Media library files are migrated as [content item assets](https://docs.kentico.com/x/content_item_assets_xp) to Content hub into a content folder `<site_name>/<library_folder>`. All assets are created in the default language of the respective site. Migrated assets are created as content items of a _Legacy media file_ content type (code name `Legacy.Mediafile`) created by the tool.
 
-If you want to use Xperience by Kentico's [automatic image optimization](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#configure-asset-content-types) feature for the _Legacy media file_ type, follow along with our [guide about customizing asset migration](https://docs.kentico.com/x/optimize_images_during_upgrade_guides).
+If you want to use Xperience by Kentico's [automatic image optimization](https://docs.kentico.com/documentation/developers-and-admins/development/content-types#configure-asset-content-types) feature for the _Legacy media file_ type, follow along with our [guide about customizing asset migration](https://docs.kentico.com/x/optimize_images_during_upgrade_guides). This guide also shows you how to make the _Legacy media file asset field_ required, so content editors must always select an asset after migration, including a code example for adding this validation rule to your migrated fields.
 
 If required, you can [configure the tool](#convert-attachments-and-media-library-files-to-media-libraries-instead-of-content-item-assets) to instead migrate media libraries as media libraries on the target instance.
 


### PR DESCRIPTION
### Motivation

The update clarifies that developers can make the _Legacy media file asset field_ required during migration, so content editors must select an asset after migration. The guide also includes a code example for adding this validation rule to migrated fields.

### Checklist

- [ ] Code follows coding conventions held in this repo - N/A, documentation-only update
- [ ] Automated tests have been added - N/A, documentation-only update
- [ ] Tests are passing - N/A, documentation-only update
- [x] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults - N/A, documentation-only update

### How to test

If manual testing is required, what are the steps?
- N/A, documentation-only update