### PR TITLE
Combined content selector - allowed types - duplicate records - fix

### DIFF
--- a/KVA/Migration.Tool.Source/Mappers/ContentItemMapper.cs
+++ b/KVA/Migration.Tool.Source/Mappers/ContentItemMapper.cs
@@ -1064,11 +1064,15 @@ public class ContentItemMapper(
         if (!allowedTypesDict.Contains(sourceNodeClassID))
         {
             var fieldInfo = targetClassFormInfo.GetFormField(targetFieldName);
-            var guidList = new List<Guid>();
+            if (fieldInfo is null)
+            {
+                return;
+            }
+            var guidList = new HashSet<Guid>();
             string? settingsString = fieldInfo.Settings[FormDefinitionPatcher.AllowedContentItemTypeIdentifiers] as string;
             if (settingsString is not null)
             {
-                guidList.AddRange(JsonConvert.DeserializeObject<Guid[]>(settingsString)!);
+                guidList.UnionWith(JsonConvert.DeserializeObject<Guid[]>(settingsString)!);
             }
             guidList.Add(modelFacade.SelectById<ICmsClass>(sourceNodeClassID)!.ClassGUID);
             settingsString = JsonConvert.SerializeObject(guidList.ToArray());


### PR DESCRIPTION
Refactor allowed content item type identifiers handling to use HashSet for uniqueness.

### Motivation

Which issue does this fix? Fixes #`656`

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

See the reproduction steps in #`656` and the expected behavior. 